### PR TITLE
Issue #50: Specify a list of commit hashes to generate report for

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,17 @@ patch-filter
 path/to/baseConfig.xml
 # path to the patch checkstyle config file. It will be applied to patch-filter branch
 path/to/patchConfig.xml
-# num of commits will be used to create patch-filter report
-# example is 4, then 3 reports will be created.
+# commit parameter will be used to create patch-filter report
+# if commit parameter is number then the Generator will work in sequence mode,
+# for example if commit parameter is 4, then 3 reports that represent 
+# the first three commits in HEAD branch will be created.
+4 # sequence mode
 # Attention: num should be greater than 1, because if num is 1, no report will be created.
-4
+
+# if commit parameter is a comma separated list of commit hashes then the Generator will work in set mode,
+# for example if commit parameter is 86bf3a482c68a3a466b278ae4c7bba4bd7be1d9c,aafac1c6d794750aeba9213e9b15a0b8f0e54f81
+# then 2 report that represent the two commit will be created if they belong to the HEAD branch.
+86bf3a482c68a3a466b278ae4c7bba4bd7be1d9c,aafac1c6d794750aeba9213e9b15a0b8f0e54f81 # set mode
 ```
 after above, if everything is ok, reports will be created in `/path/to/patch-filters/DiffReport/`.
 for example, when `repopath` is guava and `runPatchNum` is 4, then result will look like:

--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFile.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFile.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.DiffEntry;
@@ -159,6 +160,25 @@ public class GeneratePatchFile {
         final List<RevCommit> commitList = getAllCommits();
         for (int i = 0; i < runPatchNum - 1; i++) {
             generateTwoCommitDiffPatch(commitList.get(i + 1), commitList.get(i));
+        }
+        generateSummaryIndexHtml();
+    }
+
+    /**
+     * To generate patch file through jgit.
+     *
+     * @param commits a set of commitIDs
+     * @throws Exception exception
+     */
+    public void generatePatch(Set<String> commits) throws Exception {
+        final List<RevCommit> revisions = getAllCommits();
+        for (int i = 0; i < revisions.size() - 1; ++i) {
+            final RevCommit rev = revisions.get(i);
+            final String name = rev.getId().getName();
+            if (commits.contains(name)) {
+                final RevCommit prevRev = revisions.get(i + 1);
+                generateTwoCommitDiffPatch(prevRev, rev);
+            }
         }
         generateSummaryIndexHtml();
     }

--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileLauncher.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileLauncher.java
@@ -20,6 +20,9 @@
 package com.github.checkstyle.generatepatchfile;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * GeneratePatchFileWithGitCommandLauncher.
@@ -45,6 +48,14 @@ public final class GeneratePatchFileLauncher {
         final GeneratePatchFile generatePatchFile =
                 new GeneratePatchFile(repoPath, testerPath, checkstyleRepoPath,
                         checkstyleBranch, baseConfigFile, patchConfigFile);
-        generatePatchFile.generatePatch(Integer.parseInt(args[6]));
+        final String commitParam = args[6];
+        if (commitParam.matches("(0|[1-9]\\d*)")) {
+            generatePatchFile.generatePatch(Integer.parseInt(args[6]));
+        }
+        else {
+            final String[] commitIds = commitParam.split(",");
+            final Set<String> commitSet = new HashSet<>(Arrays.asList(commitIds));
+            generatePatchFile.generatePatch(commitSet);
+        }
     }
 }


### PR DESCRIPTION
Issue #50: Specify a list of commit hashes to generate report for

now I implement the function that you can use generateTwoCommitDiffPatch to generate any diff report with two commit SHA, for example the commit SHA 31999ae and the commit SHA before 31999ae——c34f584, so it will generate diff report
which represents the commit 31999ae. As for a list of commit hashes and generate reports for those commits, I will implement later. 