### PR TITLE
Issue #34: use system variable to customize path patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,10 @@ patchConfig need Checks and patch-filter, added checks can
 refer to [here](https://github.com/checkstyle/checkstyle/blob/ec4d06712ab203d31d73c5c6d5c46067f3a6d5b3/config/checkstyle_checks.xml#L60-L190), 
 you can skip Translation Check and checks that reuqires extra config file (Header and RegExpHeader), patchfilter setting is like:
 ```xml
-<module name="com.github.checkstyle.patchfilter.SuppressionPatchFilter">
-    <property name="file" value="path/to/patch-filters/DiffReport/patch.txt"/>
+<module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+        <property name="file" value="${checkstyle.patchfilter.patch}"/>
 </module>
 ```
-value should be absolute path
 
 ### Open this repo in IDEA or other IDE
 
@@ -78,8 +77,12 @@ path/to/patchConfig.xml
 # Attention: num should be greater than 1, because if num is 1, no report will be created.
 4
 ```
+then, add Environment variables:
+```bash
+checkstyle.patchfilter.patch=/path/to/patch-filters/DiffReport/patch.txt
+```
 after above, if everything is ok, reports will be created in `/path/to/patch-filters/DiffReport/`.
-for example, when `repopath` is guava and `runPatchNum` is 4, then result will look like:
+for example, when `repoPath` is guava and `runPatchNum` is 4, then result will look like:
 
 - DiffReport
   - guava-a1b3c06

--- a/src/main/resources/patchConfig.xml
+++ b/src/main/resources/patchConfig.xml
@@ -18,7 +18,7 @@
     </module>
 
     <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
-        <property name="file" value="/Users/hgh/Documents/GitHub/patch-filters/DiffReport/patch.txt"/>
+        <property name="file" value="${checkstyle.patchfilter.patch}"/>
     </module>
 
     <!--<module name="Header">-->


### PR DESCRIPTION
Issue #34: use system variable to customize path patch

Need to modify `patch-filter-jar` in contribution repo: add to `<propertyExpansion>checkstyle.pathfilter.patch=${checkstyle.pathfilter.patch.from.env}</propertyExpansion>` to `contribution/checkstyle-tester/pom.xml`

```xml
<plugin>
       <groupId>org.apache.maven.plugins</groupId>
	<artifactId>maven-checkstyle-plugin</artifactId>
	<version>${checkstyle-plugin.version}</version>
	<!-- 	Specifying configuration here will take effect on the execution of "mvn site",
			but will not take effect on the execution of "mvn checkstyle:checkstyle"  -->
	<configuration>
	         <enableFilesSummary>false</enableFilesSummary>
	         <failsOnError>${checkstyle.failsOnError}</failsOnError>
                 <propertyExpansion>checkstyle.pathfilter.patch=${checkstyle.pathfilter.patch.from.env}</propertyExpansion>
         </configuration>
</plugin>
```