### PR TITLE
Issue #37: Take exact changed lines and only show violation on them, not all lines in patch file

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,5 +13,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Install java-diff-utils 4.8-SNAPSHOT
+      run: |
+        git clone https://github.com/java-diff-utils/java-diff-utils.git
+        cd java-diff-utils/
+        mvn clean install
     - name: Build with Maven
-      run: mvn install
+      run: mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.github.java-diff-utils</groupId>
             <artifactId>java-diff-utils</artifactId>
-            <version>4.5</version>
+            <version>4.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilter.java
@@ -161,10 +161,7 @@ public class SuppressionPatchFilter extends AutomaticBean
         final List<List<Integer>> lineRangeList = new ArrayList<>();
         for (int i = 0; i < patch.getDeltas().size(); i++) {
             final Chunk targetChunk = patch.getDeltas().get(i).getTarget();
-            final List<Integer> lineRange = new ArrayList<>();
-            lineRange.add(targetChunk.getPosition());
-            lineRange.add(targetChunk.getPosition() + targetChunk.getLines().size());
-            lineRangeList.add(lineRange);
+            lineRangeList.add(targetChunk.getChangePosition());
         }
         return lineRangeList;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
@@ -74,11 +74,8 @@ public class SuppressionPatchFilterElement implements Filter {
     private boolean isLineMatching(AuditEvent event) {
         boolean result = false;
         if (event.getLocalizedMessage() != null) {
-            for (List<Integer> aLineRangeList : lineRangeList) {
-                final int startLine = aLineRangeList.get(0);
-                final int endLine = aLineRangeList.get(1);
-                final int currentLine = event.getLine();
-                result = currentLine >= startLine && currentLine <= endLine;
+            for (List<Integer> addLineRangeList : lineRangeList) {
+                result = addLineRangeList.contains(event.getLine());
                 if (result) {
                     break;
                 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/UnifiedDiffReaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/UnifiedDiffReaderTest.java
@@ -121,7 +121,7 @@ public class UnifiedDiffReaderTest extends AbstractModuleTestSupport {
         assertEquals("pom.xml", file1.getToFile());
         assertEquals(1, file1.getPatch().getDeltas().size());
 
-        assertEquals("2.7.4\n\n", diff.getTail());
+        assertEquals("2.7.4\n", diff.getTail());
     }
 
     @Test
@@ -190,13 +190,10 @@ public class UnifiedDiffReaderTest extends AbstractModuleTestSupport {
                 file1.getToFile());
         assertEquals(1, file1.getPatch().getDeltas().size());
 
-        assertEquals("2.25.1.windows.1\n\n", diff.getTail());
+        assertEquals("2.25.1.windows.1\n", diff.getTail());
     }
 
     @Test
-    @Ignore("filename parsed error, Expected :<tests/test-check-pyflakes.t>, "
-            + "Actual :<tests/test-check-pyflakes.t\tTue Jun 09 17:13:26 2020 -0400>\n"
-            + "until https://github.com/java-diff-utils/java-diff-utils/issues/85")
     public void testHgDiffPatch() throws Exception {
         final UnifiedDiff diff = getUnifiedDiff("PatchFileFromDiffTools/HGDiffPatch.txt");
         assertEquals(1, diff.getFiles().size());

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/eclipse-cs-patch-1c057d1-9d473b4.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/eclipse-cs-patch-1c057d1-9d473b4.txt
@@ -1,0 +1,1078 @@
+diff --git a/net.sf.eclipsecs.checkstyle/.classpath b/net.sf.eclipsecs.checkstyle/.classpath
+index 5bf2de5..e29ade0 100644
+--- a/net.sf.eclipsecs.checkstyle/.classpath
++++ b/net.sf.eclipsecs.checkstyle/.classpath
+@@ -13,6 +13,6 @@
+ 			<attribute name="test" value="true"/>
+ 		</attributes>
+ 	</classpathentry>
+-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
++	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
+ 	<classpathentry kind="output" path="target/classes"/>
+ </classpath>
+diff --git a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
+index aa928ab..7f93778 100644
+--- a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
++++ b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
+@@ -1,6 +1,11 @@
+ package net.sf.eclipsecs.checkstyle;
+
+ import static java.nio.charset.StandardCharsets.UTF_8;
++import static org.junit.jupiter.api.Assertions.assertEquals;
++import static org.junit.jupiter.api.Assertions.assertNotNull;
++import static org.junit.jupiter.api.Assertions.assertNull;
++import static org.junit.jupiter.api.Assertions.assertTrue;
++import static org.junit.jupiter.api.Assertions.fail;
+
+ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+ import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
+@@ -19,8 +24,7 @@
+ import net.sf.eclipsecs.checkstyle.utils.CheckUtil;
+ import net.sf.eclipsecs.checkstyle.utils.XmlUtil;
+
+-import org.junit.Assert;
+-import org.junit.Test;
++import org.junit.jupiter.api.Test;
+ import org.w3c.dom.Document;
+ import org.w3c.dom.NamedNodeMap;
+ import org.w3c.dom.Node;
+@@ -32,11 +36,10 @@
+     final Set<Class<?>> modules = CheckUtil.getCheckstyleModules();
+     final Set<String> packages = CheckUtil.getPackages(modules);
+
+-    Assert.assertTrue("no modules", modules.size() > 0);
++    assertTrue(modules.size() > 0, "no modules");
+
+     for (String p : packages) {
+-      Assert.assertTrue("folder " + p + " must exist in eclipsecs",
+-              new File(getEclipseCsPath(p, "")).exists());
++      assertTrue(new File(getEclipseCsPath(p, "")).exists(), "folder " + p + " must exist in eclipsecs");
+
+       final Set<Class<?>> packgeModules = CheckUtil.getModulesInPackage(modules, p);
+
+@@ -51,16 +54,14 @@
+
+   private static void validateEclipseCsMetaXmlFile(File file, String packge,
+           Set<Class<?>> packgeModules) throws Exception {
+-    Assert.assertTrue("'checkstyle-metadata.xml' must exist in eclipsecs in inside " + packge,
+-            file.exists());
++    assertTrue(file.exists(), "'checkstyle-metadata.xml' must exist in eclipsecs in inside " + packge);
+
+     final String input = new String(Files.readAllBytes(file.toPath()), UTF_8);
+     final Document document = XmlUtil.getRawXml(file.getAbsolutePath(), input, input);
+
+     final NodeList ruleGroups = document.getElementsByTagName("rule-group-metadata");
+
+-    Assert.assertEquals(packge + " checkstyle-metadata.xml must contain only one rule group", 1,
+-            ruleGroups.getLength());
++    assertEquals(1, ruleGroups.getLength(), packge + " checkstyle-metadata.xml must contain only one rule group");
+
+     for (int position = 0; position < ruleGroups.getLength(); position++) {
+       final Node ruleGroup = ruleGroups.item(position);
+@@ -70,7 +71,7 @@
+     }
+
+     for (Class<?> module : packgeModules) {
+-      Assert.fail("Module not found in " + packge + " checkstyle-metadata.xml: "
++      fail("Module not found in " + packge + " checkstyle-metadata.xml: "
+               + module.getCanonicalName());
+     }
+   }
+@@ -81,8 +82,7 @@
+       final NamedNodeMap attributes = rule.getAttributes();
+       final Node internalNameNode = attributes.getNamedItem("internal-name");
+
+-      Assert.assertNotNull(packge + " checkstyle-metadata.xml must contain an internal name",
+-              internalNameNode);
++      assertNotNull(internalNameNode, packge + " checkstyle-metadata.xml must contain an internal name");
+
+       final String internalName = internalNameNode.getTextContent();
+       final String classpath = packge + "." + internalName;
+@@ -90,17 +90,14 @@
+       final Class<?> module = findModule(packgeModules, classpath);
+       packgeModules.remove(module);
+
+-      Assert.assertNotNull(
+-              "Unknown class found in " + packge + " checkstyle-metadata.xml: " + internalName,
+-              module);
++      assertNotNull(module,
++              "Unknown class found in " + packge + " checkstyle-metadata.xml: " + internalName);
+
+       final Node nameAttribute = attributes.getNamedItem("name");
+
+-      Assert.assertNotNull(packge + " checkstyle-metadata.xml requires a name for " + internalName,
+-              nameAttribute);
+-      Assert.assertEquals(
+-              packge + " checkstyle-metadata.xml requires a valid name for " + internalName,
+-              "%" + internalName + ".name", nameAttribute.getTextContent());
++      assertNotNull(nameAttribute, packge + " checkstyle-metadata.xml requires a name for " + internalName);
++      assertEquals("%" + internalName + ".name", nameAttribute.getTextContent(),
++              packge + " checkstyle-metadata.xml requires a valid name for " + internalName);
+
+       final Node parentAttribute = attributes.getNamedItem("parent");
+       final String parentValue;
+@@ -114,12 +111,10 @@
+         parentValue = "Checker";
+       }
+
+-      Assert.assertNotNull(
+-              packge + " checkstyle-metadata.xml requires a parent for " + internalName,
+-              parentAttribute);
+-      Assert.assertEquals(
+-              packge + " checkstyle-metadata.xml requires a valid parent for " + internalName,
+-              parentValue, parentAttribute.getTextContent());
++      assertNotNull(parentAttribute,
++              packge + " checkstyle-metadata.xml requires a parent for " + internalName);
++      assertEquals(parentValue, parentAttribute.getTextContent(),
++              packge + " checkstyle-metadata.xml requires a valid parent for " + internalName);
+
+       final Set<Node> children = XmlUtil.getChildrenElements(rule);
+
+@@ -151,60 +146,57 @@
+         case "alternative-name":
+           final Node internalNameNode = attributes.getNamedItem("internal-name");
+
+-          Assert.assertNotNull(packge
+-                  + " checkstyle-metadata.xml must contain an internal name for " + moduleName,
+-                  internalNameNode);
++          assertNotNull(internalNameNode, packge
++                  + " checkstyle-metadata.xml must contain an internal name for " + moduleName);
+
+           final String internalName = internalNameNode.getTextContent();
+
+-          Assert.assertEquals(packge
+-                  + " checkstyle-metadata.xml requires a valid internal-name for " + moduleName,
+-                  module.getName(), internalName);
++          assertEquals(module.getName(), internalName, packge
++                  + " checkstyle-metadata.xml requires a valid internal-name for " + moduleName);
+           break;
+         case "description":
+-          Assert.assertEquals(packge + " checkstyle-metadata.xml requires a valid description for "
+-                  + moduleName, "%" + moduleName + ".desc", child.getTextContent());
++          assertEquals("%" + moduleName + ".desc", child.getTextContent(), packge + " checkstyle-metadata.xml requires a valid description for "
++                  + moduleName);
+           break;
+         case "property-metadata":
+           final String propertyName = attributes.getNamedItem("name").getTextContent();
+
+-          Assert.assertTrue(packge + " checkstyle-metadata.xml has an unknown parameter for "
+-                  + moduleName + ": " + propertyName, properties.remove(propertyName));
++          assertTrue(properties.remove(propertyName), packge + " checkstyle-metadata.xml has an unknown parameter for "
++                  + moduleName + ": " + propertyName);
+
+           validateEclipseCsMetaXmlFileRuleProperty(packge, module, moduleName, propertyName, child);
+           break;
+         case "message-key":
+           final String key = attributes.getNamedItem("key").getTextContent();
+
+-          Assert.assertTrue(packge + " checkstyle-metadata.xml has an unknown message for "
+-                  + moduleName + ": " + key, messages.remove(key));
++          assertTrue(messages.remove(key), packge + " checkstyle-metadata.xml has an unknown message for "
++                  + moduleName + ": " + key);
+           break;
+         case "quickfix":
+           final String className = attributes.getNamedItem("classname").getTextContent();
+
+-          Assert.assertEquals(packge
+-                  + " checkstyle-metadata.xml should have a valid quickfix class for " + moduleName,
+-                  quickfixClass, className);
++          assertEquals(quickfixClass, className, packge
++                  + " checkstyle-metadata.xml should have a valid quickfix class for " + moduleName);
+
+           quickfixClass = null;
+           break;
+         default:
+-          Assert.fail(packge + " checkstyle-metadata.xml unknown node for " + moduleName + ": "
++          fail(packge + " checkstyle-metadata.xml unknown node for " + moduleName + ": "
+                   + child.getNodeName());
+           break;
+       }
+     }
+
+-    Assert.assertNull(packge + " checkstyle-metadata.xml missing quickfix for " + moduleName + ": "
+-            + quickfixClass, quickfixClass);
++    assertNull(quickfixClass, packge + " checkstyle-metadata.xml missing quickfix for " + moduleName + ": "
++            + quickfixClass);
+
+     for (String property : properties) {
+-      Assert.fail(packge + " checkstyle-metadata.xml missing parameter for " + moduleName + ": "
++      fail(packge + " checkstyle-metadata.xml missing parameter for " + moduleName + ": "
+               + property);
+     }
+
+     for (String message : messages) {
+-      Assert.fail(packge + " checkstyle-metadata.xml missing message for " + moduleName + ": "
++      fail(packge + " checkstyle-metadata.xml missing message for " + moduleName + ": "
+               + message);
+     }
+   }
+@@ -213,16 +205,14 @@
+           String moduleName, String propertyName, Node propertyNode) throws Exception {
+     final Node firstChild = propertyNode.getFirstChild().getNextSibling();
+
+-    Assert.assertNotNull(packge + " checkstyle-metadata.xml requires atleast one child for "
+-            + moduleName + ", " + propertyName, firstChild);
+-    Assert.assertEquals(
++    assertNotNull(firstChild, packge + " checkstyle-metadata.xml requires atleast one child for "
++            + moduleName + ", " + propertyName);
++    assertEquals("description", firstChild.getNodeName(),
+             packge + " checkstyle-metadata.xml should have a description for the "
+-                    + "first child of " + moduleName + ", " + propertyName,
+-            "description", firstChild.getNodeName());
+-    Assert.assertEquals(
++                    + "first child of " + moduleName + ", " + propertyName);
++    assertEquals("%" + moduleName + "." + propertyName, firstChild.getTextContent(),
+             packge + " checkstyle-metadata.xml requires a valid description for " + moduleName
+-                    + ", " + propertyName,
+-            "%" + moduleName + "." + propertyName, firstChild.getTextContent());
++            + ", " + propertyName);
+
+     if ("tokens".equals(propertyName)) {
+       validateEclipseCsMetaXmlFileRuleTokens(packge, module, moduleName, propertyName,
+@@ -244,31 +234,29 @@
+     final Node defaultValueNode = propertyNode.getAttributes().getNamedItem("default-value");
+
+     if (defaultText == null) {
+-      Assert.assertNull(packge + " checkstyle-metadata.xml should not have a default value for "
+-              + moduleName + ", " + propertyName, defaultValueNode);
++      assertNull(defaultValueNode, packge + " checkstyle-metadata.xml should not have a default value for "
++              + moduleName + ", " + propertyName);
+     } else {
+-      Assert.assertNotNull(packge + " checkstyle-metadata.xml requires a default value for "
+-              + moduleName + ", " + propertyName, defaultValueNode);
++      assertNotNull(defaultValueNode, packge + " checkstyle-metadata.xml requires a default value for "
++              + moduleName + ", " + propertyName);
+
+-      Assert.assertEquals(packge + " checkstyle-metadata.xml requires a valid default value for "
+-              + moduleName + ", " + propertyName, defaultText, defaultValueNode.getTextContent());
++      assertEquals(defaultText, defaultValueNode.getTextContent(), packge + " checkstyle-metadata.xml requires a valid default value for "
++              + moduleName + ", " + propertyName);
+     }
+
+     final Node enumerationChild = propertyNode.getFirstChild().getNextSibling().getNextSibling()
+             .getNextSibling();
+
+     if (acceptableText == null) {
+-      Assert.assertNull(
++      assertNull(enumerationChild,
+               packge + " checkstyle-metadata.xml should not have an enumeration child for "
+-                      + moduleName + ", " + propertyName,
+-              enumerationChild);
++                      + moduleName + ", " + propertyName);
+     } else {
+-      Assert.assertNotNull(packge + " checkstyle-metadata.xml requires an enumeration child for "
+-              + moduleName + ", " + propertyName, enumerationChild);
+-      Assert.assertEquals(
++      assertNotNull(enumerationChild, packge + " checkstyle-metadata.xml requires an enumeration child for "
++              + moduleName + ", " + propertyName);
++      assertEquals("enumeration", enumerationChild.getNodeName(),
+               packge + " checkstyle-metadata.xml should have a enumeration for the " + " child of "
+-                      + moduleName + ", " + propertyName,
+-              "enumeration", enumerationChild.getNodeName());
++                      + moduleName + ", " + propertyName);
+
+       if ("TokenTypes".equals(acceptableText)) {
+         // TODO
+@@ -281,20 +269,19 @@
+             case "property-value-option":
+               final String value = child.getAttributes().getNamedItem("value").getTextContent();
+
+-              Assert.assertTrue(
++              assertTrue(options.remove(value),
+                       packge + " checkstyle-metadata.xml has an unknown acceptable token for "
+-                              + moduleName + ", " + propertyName + ": " + value,
+-                      options.remove(value));
++                              + moduleName + ", " + propertyName + ": " + value);
+               break;
+             default:
+-              Assert.fail(packge + " checkstyle-metadata.xml unknown node for " + moduleName + ", "
++              fail(packge + " checkstyle-metadata.xml unknown node for " + moduleName + ", "
+                       + propertyName + ": " + child.getNodeName());
+               break;
+           }
+         }
+
+         for (String option : options) {
+-          Assert.fail(packge + " checkstyle-metadata.xml missing acceptable token for " + moduleName
++          fail(packge + " checkstyle-metadata.xml missing acceptable token for " + moduleName
+                   + ", " + propertyName + ": " + option);
+         }
+       }
+@@ -331,9 +318,7 @@
+
+   private static void validateEclipseCsMetaPropFile(File file, String packge,
+           Set<Class<?>> packgeModules) throws Exception {
+-    Assert.assertTrue(
+-            "'checkstyle-metadata.properties' must exist in eclipsecs in inside " + packge,
+-            file.exists());
++    assertTrue(file.exists(), "'checkstyle-metadata.properties' must exist in eclipsecs in inside " + packge);
+
+     final Properties prop = new Properties();
+     prop.load(new FileInputStream(file));
+@@ -343,25 +328,22 @@
+     for (Class<?> module : packgeModules) {
+       final String moduleName = CheckUtil.getSimpleCheckstyleModuleName(module);
+
+-      Assert.assertTrue(moduleName + " requires a name in eclipsecs properties " + packge,
+-              properties.remove(moduleName + ".name"));
+-      Assert.assertTrue(moduleName + " requires a desc in eclipsecs properties " + packge,
+-              properties.remove(moduleName + ".desc"));
++      assertTrue(properties.remove(moduleName + ".name"), moduleName + " requires a name in eclipsecs properties " + packge);
++      assertTrue(properties.remove(moduleName + ".desc"), moduleName + " requires a desc in eclipsecs properties " + packge);
+
+       final Set<String> moduleProperties = CheckUtil.getCheckProperties(module);
+
+       for (String moduleProperty : moduleProperties) {
+-        Assert.assertTrue(
++        assertTrue(properties.remove(moduleName + "." + moduleProperty),
+                 moduleName + " requires the property " + moduleProperty
+-                        + " in eclipsecs properties " + packge,
+-                properties.remove(moduleName + "." + moduleProperty));
++                + " in eclipsecs properties " + packge);
+       }
+     }
+
+     for (Object property : properties) {
+       // ignore group names
+       if (!property.toString().endsWith(".group")) {
+-        Assert.fail("Unknown property found in eclipsecs properties " + packge + ": " + property);
++        fail("Unknown property found in eclipsecs properties " + packge + ": " + property);
+       }
+     }
+   }
+diff --git a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/XmlUtil.java b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/XmlUtil.java
+index bee3d2a..8f15cd5 100644
+--- a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/XmlUtil.java
++++ b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/XmlUtil.java
+@@ -1,12 +1,13 @@
+ package net.sf.eclipsecs.checkstyle.utils;
+
++import static org.junit.jupiter.api.Assertions.fail;
++
+ import java.io.IOException;
+ import java.io.StringReader;
+ import java.util.LinkedHashSet;
+ import java.util.Set;
+ import java.util.stream.Collectors;
+
+-import org.junit.Assert;
+ import org.w3c.dom.Document;
+ import org.w3c.dom.Node;
+ import org.xml.sax.EntityResolver;
+@@ -42,7 +43,7 @@
+
+       rawXml = builder.parse(new InputSource(new StringReader(code)));
+     } catch (IOException | SAXException ex) {
+-      Assert.fail(fileName + " has invalid xml (" + ex.getMessage() + "): " + unserializedSource);
++      fail(fileName + " has invalid xml (" + ex.getMessage() + "): " + unserializedSource);
+     }
+
+     return rawXml;
+diff --git a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+index 3398e5e..965e67a 100644
+--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
++++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+@@ -1,13 +1,24 @@
+ <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+ <?pde?>
+-<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+-<target name="Eclipse Checkstyle" sequenceNumber="1590429360">
++<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
++<target name="Eclipse Checkstyle" sequenceNumber="1591014598">
+   <locations>
+     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+       <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+       <unit id="org.eclipse.sdk.ide" version="0.0.0"/>
+       <unit id="org.eclipse.emf.feature.group" version="0.0.0"/>
+-      <repository location="http://download.eclipse.org/releases/juno/201303010900/"/>
++      <repository location="https://download.eclipse.org/releases/juno/201303010900/"/>
++    </location>
++    <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
++      <unit id="org.junit.jupiter.api" version="0.0.0"/>
++      <unit id="org.junit.jupiter.engine" version="0.0.0"/>
++      <unit id="org.junit.jupiter.params" version="0.0.0"/>
++      <unit id="org.junit.platform.commons" version="0.0.0"/>
++      <unit id="org.junit.platform.engine" version="0.0.0"/>
++      <unit id="org.junit.platform.launcher" version="0.0.0"/>
++      <unit id="org.junit.platform.runner" version="0.0.0"/>
++      <unit id="org.junit.platform.suite.api" version="0.0.0"/>
++      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository"/>
+     </location>
+   </locations>
+   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+diff --git a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+index 936cf13..09f914a 100644
+--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
++++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+@@ -1,14 +1,26 @@
+-// Install http://download.eclipse.org/cbi/tpd/3.0.0-SNAPSHOT/ to use this target definition.
++// Install https://download.eclipse.org/cbi/tpd/3.0.0-SNAPSHOT/ to use this target definition.
+ // Read https://github.com/eclipse-cbi/targetplatform-dsl for more details.
+ target "Eclipse Checkstyle"
+ with source configurePhase
+ environment JavaSE-1.8
+
+ // use the latest version of Juno only, to avoid downloading all children of the Juno composite update site
+-location "http://download.eclipse.org/releases/juno/201303010900/" {
++location "https://download.eclipse.org/releases/juno/201303010900/" {
+ 	org.eclipse.jdt.feature.group lazy
+ 	org.eclipse.sdk.ide lazy
+
+ 	// e4.ui has dependencies to EMF, those are not actually needed by eclipse-cs itself
+ 	org.eclipse.emf.feature.group lazy
+ }
++
++// latest release of JUnit 5 from Eclipse Orbit
++location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository" {
++	org.junit.jupiter.api lazy
++	org.junit.jupiter.engine lazy
++	org.junit.jupiter.params lazy
++	org.junit.platform.commons lazy
++	org.junit.platform.engine lazy
++	org.junit.platform.launcher lazy
++	org.junit.platform.runner lazy
++	org.junit.platform.suite.api lazy
++}
+\ No newline at end of file
+diff --git a/net.sf.eclipsecs.ui/.classpath b/net.sf.eclipsecs.ui/.classpath
+index 22a2c7d..1d985b3 100644
+--- a/net.sf.eclipsecs.ui/.classpath
++++ b/net.sf.eclipsecs.ui/.classpath
+@@ -15,6 +15,6 @@
+ 	<classpathentry exported="true" kind="lib" path="lib/jfreechart-1.0.19.jar"/>
+ 	<classpathentry exported="true" kind="lib" path="lib/jfreechart-1.0.19-swt.jar"/>
+ 	<classpathentry exported="true" kind="lib" path="lib/jcommon-1.0.23.jar"/>
+-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
++	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
+ 	<classpathentry kind="output" path="target/classes"/>
+ </classpath>
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/AbstractQuickfixTestCase.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/AbstractQuickfixTestCase.java
+index 925e03c..16dc326 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/AbstractQuickfixTestCase.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/AbstractQuickfixTestCase.java
+@@ -2,6 +2,9 @@
+
+ import com.google.common.base.Strings;
+
++import static org.junit.jupiter.api.Assertions.assertEquals;
++import static org.junit.jupiter.api.Assertions.assertNotNull;
++
+ import java.io.InputStream;
+ import java.util.ArrayList;
+ import java.util.HashMap;
+@@ -16,22 +19,20 @@
+ import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+ import org.eclipse.jface.text.IRegion;
+ import org.eclipse.text.edits.TextEdit;
+-import org.junit.Assert;
+ import org.w3c.dom.Document;
+ import org.w3c.dom.Element;
+ import org.w3c.dom.NodeList;
+
+ import javax.xml.parsers.DocumentBuilder;
+ import javax.xml.parsers.DocumentBuilderFactory;
+-import junit.framework.TestCase;
+
+-public abstract class AbstractQuickfixTestCase extends TestCase {
++public abstract class AbstractQuickfixTestCase {
+
+   protected void testQuickfix(final String testDataXml, final AbstractASTResolution quickfix)
+           throws Exception {
+     InputStream stream = getClass().getResourceAsStream(testDataXml);
+-    assertNotNull("Cannot find resource " + testDataXml + " in package "
+-            + getClass().getPackage().getName(), stream);
++    assertNotNull(stream, "Cannot find resource " + testDataXml + " in package "
++            + getClass().getPackage().getName());
+     try {
+       System.out.println(
+               "Test quickfix " + quickfix.getClass() + " with input file `" + testDataXml + "`");
+@@ -73,7 +74,7 @@
+       TextEdit edit = compUnit.rewrite(doc, options);
+       edit.apply(doc);
+
+-      Assert.assertEquals(testdata[i].result, doc.get());
++      assertEquals(testdata[i].result, doc.get());
+     }
+
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java
+index aec12c2..be27e03 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java
+@@ -1,10 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.blocks;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class AvoidNestedBlocksTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testAvoidNestedBlocks() throws Exception {
+     testQuickfix("AvoidNestedBlocksInput.xml", new AvoidNestedBlocksQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java
+index 57efba1..1b82fe3 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java
+@@ -1,30 +1,38 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.blocks;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class NeedBracesTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testNeedBracesIf() throws Exception {
+     testQuickfix("NeedBracesInputIf.xml", new NeedBracesQuickfix());
+   }
+
++  @Test
+   public void testNeedBracesElse() throws Exception {
+     testQuickfix("NeedBracesInputElse.xml", new NeedBracesQuickfix());
+   }
+
++  @Test
+   public void testNeedBracesElseIf() throws Exception {
+     testQuickfix("NeedBracesInputElseIf.xml", new NeedBracesQuickfix());
+   }
+
++  @Test
+   public void testNeedBracesFor() throws Exception {
+     testQuickfix("NeedBracesInputFor.xml", new NeedBracesQuickfix());
+   }
+
++  @Test
+   public void testNeedBracesWhile() throws Exception {
+     testQuickfix("NeedBracesInputWhile.xml", new NeedBracesQuickfix());
+   }
+
++  @Test
+   public void testNeedBracesDoWhile() throws Exception {
+     testQuickfix("NeedBracesInputDoWhile.xml", new NeedBracesQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java
+index bc0002a..0a708a3 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java
+@@ -1,14 +1,18 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.coding;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class DefaultComesLastTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testDefaultComesLast() throws Exception {
+     testQuickfix("DefaultComesLastInput.xml", new DefaultComesLastQuickfix());
+   }
+
++  @Test
+   public void testDefaultComesLastInner() throws Exception {
+     testQuickfix("DefaultComesLastInputInner.xml", new DefaultComesLastQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java
+index 552289e..acfc5b3 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java
+@@ -1,14 +1,18 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.coding;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class EmptyStatementTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testEmptyStatement() throws Exception {
+     testQuickfix("EmptyStatementInput.xml", new EmptyStatementQuickfix());
+   }
+
++  @Test
+   public void testEmptyStatementNeg() throws Exception {
+     testQuickfix("EmptyStatementInputNeg.xml", new EmptyStatementQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java
+index 391655d..5a849a3 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java
+@@ -1,11 +1,14 @@
+ package net.sf.eclipsecs.ui.quickfixes.coding;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class ExplicitInitializationTest extends AbstractQuickfixTestCase {
+
+-    public void testExplicitInitialization() throws Exception {
+-        testQuickfix("ExplicitInitialization.xml", new ExplicitInitializationQuickfix());
+-    }
++  @Test
++  public void testExplicitInitialization() throws Exception {
++    testQuickfix("ExplicitInitialization.xml", new ExplicitInitializationQuickfix());
++  }
+
+ }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java
+index 18d1120..81eeecd 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java
+@@ -1,10 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.coding;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class FinalLocalVariableTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testFinalLocalVariable() throws Exception {
+     testQuickfix("FinalLocalVariableInput.xml", new FinalLocalVariableQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java
+index 157df5d..4843a39 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java
+@@ -1,14 +1,18 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.coding;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class MissingSwitchDefaultTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testMissingSwitchDefault() throws Exception {
+     testQuickfix("MissingSwitchDefaultInput.xml", new MissingSwitchDefaultQuickfix());
+   }
+
++  @Test
+   public void testMissingSwitchDefaultInner() throws Exception {
+     testQuickfix("MissingSwitchDefaultInputInner.xml", new MissingSwitchDefaultQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java
+index 4cbea2c..7db2024 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java
+@@ -1,43 +1,54 @@
+ package net.sf.eclipsecs.ui.quickfixes.coding;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class RequireThisTest extends AbstractQuickfixTestCase {
+
+-    public void testRequireThisFieldAccessAssignmentLHS() throws Exception {
+-        testQuickfix("RequireThisFieldAccessAssignmentLHS.xml", new RequireThisQuickfix());
+-    }
++  @Test
++  public void testRequireThisFieldAccessAssignmentLHS() throws Exception {
++    testQuickfix("RequireThisFieldAccessAssignmentLHS.xml", new RequireThisQuickfix());
++  }
+
+-    public void testRequireThisFieldAccessAssignmentRHS() throws Exception {
+-        testQuickfix("RequireThisFieldAccessAssignmentRHS.xml", new RequireThisQuickfix());
+-    }
++  @Test
++  public void testRequireThisFieldAccessAssignmentRHS() throws Exception {
++    testQuickfix("RequireThisFieldAccessAssignmentRHS.xml", new RequireThisQuickfix());
++  }
+
+-    public void testRequireThisFieldAccessArrayInitializer() throws Exception {
+-        testQuickfix("RequireThisFieldAccessArrayInitializer.xml", new RequireThisQuickfix());
+-    }
++  @Test
++  public void testRequireThisFieldAccessArrayInitializer() throws Exception {
++    testQuickfix("RequireThisFieldAccessArrayInitializer.xml", new RequireThisQuickfix());
++  }
+
+-    public void testRequireThisFieldAccessInnerClass() throws Exception {
+-        testQuickfix("RequireThisFieldAccessInnerClass.xml", new RequireThisQuickfix());
+-    }
++  @Test
++  public void testRequireThisFieldAccessInnerClass() throws Exception {
++    testQuickfix("RequireThisFieldAccessInnerClass.xml", new RequireThisQuickfix());
++  }
+
+-    public void testRequireThisMethodInvocation() throws Exception {
+-        testQuickfix("RequireThisMethodInvocation.xml", new RequireThisQuickfix());
+-    }
++  @Test
++  public void testRequireThisMethodInvocation() throws Exception {
++    testQuickfix("RequireThisMethodInvocation.xml", new RequireThisQuickfix());
++  }
+
+-    public void testRequireThisMethodInvocationWithParam() throws Exception {
+-        testQuickfix("RequireThisMethodInvocationWithParam.xml", new RequireThisQuickfix());
+-    }
++  @Test
++  public void testRequireThisMethodInvocationWithParam() throws Exception {
++    testQuickfix("RequireThisMethodInvocationWithParam.xml", new RequireThisQuickfix());
++  }
+
+-    public void testRequireThisMethodInvocationAssignmentRHS() throws Exception {
+-        testQuickfix("RequireThisMethodInvocationAssignmentRHS.xml", new RequireThisQuickfix());
+-    }
++  @Test
++  public void testRequireThisMethodInvocationAssignmentRHS() throws Exception {
++    testQuickfix("RequireThisMethodInvocationAssignmentRHS.xml", new RequireThisQuickfix());
++  }
+
+-    public void testRequireThisMethodInvocationArrayInitializer() throws Exception {
+-        testQuickfix("RequireThisMethodInvocationArrayInitializer.xml", new RequireThisQuickfix());
+-    }
++  @Test
++  public void testRequireThisMethodInvocationArrayInitializer() throws Exception {
++    testQuickfix("RequireThisMethodInvocationArrayInitializer.xml", new RequireThisQuickfix());
++  }
+
+-    public void testRequireThisMethodInvocationInnerClass() throws Exception {
+-        testQuickfix("RequireThisMethodInvocationInnerClass.xml", new RequireThisQuickfix());
+-    }
++  @Test
++  public void testRequireThisMethodInvocationInnerClass() throws Exception {
++    testQuickfix("RequireThisMethodInvocationInnerClass.xml", new RequireThisQuickfix());
++  }
+
+ }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java
+index 7cd22a2..29ad024 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java
+@@ -1,55 +1,79 @@
+ package net.sf.eclipsecs.ui.quickfixes.coding;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class SimplifyBooleanReturnTest extends AbstractQuickfixTestCase {
+
+-    public void testSimplifyBooleanReturnWithoutCurlyBraces() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithoutCurlyBraces.xml", new SimplifyBooleanReturnQuickfix());
+-    }
++  @Test
++  public void testSimplifyBooleanReturnWithoutCurlyBraces() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithoutCurlyBraces.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
+
+-    public void testSimplifyBooleanReturnWithCurlyBraces() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithCurlyBraces.xml", new SimplifyBooleanReturnQuickfix());
+-    }
++  @Test
++  public void testSimplifyBooleanReturnWithCurlyBraces() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithCurlyBraces.xml", new SimplifyBooleanReturnQuickfix());
++  }
+
+-    public void testSimplifyBooleanReturnWithBooleanLiteralCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithBooleanLiteralCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
+-    public void testSimplifyBooleanReturnWithFieldAccessCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithFieldAccessCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
+-    public void testSimplifyBooleanReturnWithMethodInvocationCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithMethodInvocationCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
+-    public void testSimplifyBooleanReturnWithQualifiedNameCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithQualifiedNameCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
+-    public void testSimplifyBooleanReturnWithSimpleNameCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithSimpleNameCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
+-    public void testSimplifyBooleanReturnWithParanthesizedExpressionCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithParanthesizedExpressionCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
+-    public void testSimplifyBooleanReturnWithSuperFieldAccessCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithSuperFieldAccessCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
+-    public void testSimplifyBooleanReturnWithSuperMethodInvocationCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithSuperMethodInvocationCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
+-    public void testSimplifyBooleanReturnWithThisExpressionCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithThisExpressionCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
+-    public void testSimplifyBooleanReturnWithNotCondition() throws Exception {
+-        testQuickfix("SimplifyBooleanReturnWithNotCondition.xml", new SimplifyBooleanReturnQuickfix());
+-    }
+-
++  @Test
++  public void testSimplifyBooleanReturnWithBooleanLiteralCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithBooleanLiteralCondition.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
++
++  @Test
++  public void testSimplifyBooleanReturnWithFieldAccessCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithFieldAccessCondition.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
++
++  @Test
++  public void testSimplifyBooleanReturnWithMethodInvocationCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithMethodInvocationCondition.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
++
++  @Test
++  public void testSimplifyBooleanReturnWithQualifiedNameCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithQualifiedNameCondition.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
++
++  @Test
++  public void testSimplifyBooleanReturnWithSimpleNameCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithSimpleNameCondition.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
++
++  @Test
++  public void testSimplifyBooleanReturnWithParanthesizedExpressionCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithParanthesizedExpressionCondition.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
++
++  @Test
++  public void testSimplifyBooleanReturnWithSuperFieldAccessCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithSuperFieldAccessCondition.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
++
++  @Test
++  public void testSimplifyBooleanReturnWithSuperMethodInvocationCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithSuperMethodInvocationCondition.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
++
++  @Test
++  public void testSimplifyBooleanReturnWithThisExpressionCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithThisExpressionCondition.xml",
++            new SimplifyBooleanReturnQuickfix());
++  }
++
++  @Test
++  public void testSimplifyBooleanReturnWithNotCondition() throws Exception {
++    testQuickfix("SimplifyBooleanReturnWithNotCondition.xml", new SimplifyBooleanReturnQuickfix());
++  }
++
+ }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java
+index 302cd28..88c22a1 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java
+@@ -1,10 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.coding;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class StringLiteralEqualityTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testStringLiteralEquality() throws Exception {
+     testQuickfix("StringLiteralEqualityInput.xml", new StringLiteralEqualityQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java
+index 102ab87..5b7ca73 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java
+@@ -1,10 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.design;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class DesignForExtensionTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testDesignForExtension() throws Exception {
+     testQuickfix("DesignForExtensionInput.xml", new DesignForExtensionQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java
+index 23cbb51..beb2f4b 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java
+@@ -1,10 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.design;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class FinalClassTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testFinalClass() throws Exception {
+     testQuickfix("FinalClassInput.xml", new FinalClassQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java
+index 0c5ac78..8cb215e 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java
+@@ -1,18 +1,23 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.misc;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class ArrayTypeStyleTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testArrayTypeStyleField() throws Exception {
+     testQuickfix("ArrayTypeStyleInputField.xml", new ArrayTypeStyleQuickfix());
+   }
+
++  @Test
+   public void testArrayTypeStyleMethodParam() throws Exception {
+     testQuickfix("ArrayTypeStyleInputMethodParam.xml", new ArrayTypeStyleQuickfix());
+   }
+
++  @Test
+   public void testArrayTypeStyleVariable() throws Exception {
+     testQuickfix("ArrayTypeStyleInputVariable.xml", new ArrayTypeStyleQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java
+index a223b3c..4fe778d 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java
+@@ -1,10 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.misc;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class FinalParametersTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testFinalParameters() throws Exception {
+     testQuickfix("FinalParametersInput.xml", new FinalParametersQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java
+index 3e6c0b1..a6f0151 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java
+@@ -1,10 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.misc;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class UncommentedMainTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testUncommentedMain() throws Exception {
+     testQuickfix("UncommentedMainInput.xml", new UncommentedMainQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java
+index 80ca22a..81065f6 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java
+@@ -1,10 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.misc;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class UpperEllTest extends AbstractQuickfixTestCase {
+
++  @Test
+   public void testUpperEll() throws Exception {
+     testQuickfix("UpperEllInput.xml", new UpperEllQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java
+index f273ad5..6158d4c 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java
+@@ -1,9 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.modifier;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class ModifierOrderTest extends AbstractQuickfixTestCase {
++
++  @Test
+   public void testModifierOrder() throws Exception {
+     testQuickfix("ModifierOrderInput.xml", new ModifierOrderQuickfix());
+   }
+diff --git a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java
+index a329269..34321c7 100644
+--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java
++++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java
+@@ -1,9 +1,13 @@
+
+ package net.sf.eclipsecs.ui.quickfixes.modifier;
+
++import org.junit.jupiter.api.Test;
++
+ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
+
+ public class RedundantModifierTest extends AbstractQuickfixTestCase {
++
++  @Test
+   public void testRedundantModifier() throws Exception {
+     testQuickfix("RedundantModifierInput.xml", new RedundantModifierQuickfix());
+   }
+diff --git a/pom.xml b/pom.xml
+index a40020c..1fa52b2 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -45,9 +45,15 @@
+
+     <dependencies>
+         <dependency>
+-            <groupId>junit</groupId>
+-            <artifactId>junit</artifactId>
+-            <version>4.13</version>
++            <groupId>org.junit.jupiter</groupId>
++            <artifactId>junit-jupiter-api</artifactId>
++            <version>5.6.0</version>
++            <scope>test</scope>
++        </dependency>
++        <dependency>
++            <groupId>org.junit.jupiter</groupId>
++            <artifactId>junit-jupiter-engine</artifactId>
++            <version>5.6.0</version>
+             <scope>test</scope>
+         </dependency>
+     </dependencies>


### PR DESCRIPTION
Issue #37: Take exact changed lines and only show violation on them, not all lines in patch file

this need to clone https://github.com/HuGanghui/java-diff-utils/tree/addPosition and checkout to `addPosition` branch,  and then local install it. 

this is the first version, I think we need more tests to make sure it works.