### PR TITLE
Issue #76: Add unit tests to evaluate jgit patch parser (GitDiffCommandDefaultSize)

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffWithContextSizeDefaultTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffWithContextSizeDefaultTest.java
@@ -37,8 +37,8 @@ public class GitDiffWithContextSizeDefaultTest extends AbstractJgitPatchParserEv
         "src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/";
 
     @Test
-    public void testInsertDeleteReplaceEditTypesWithinHunk() throws IOException {
-        final String patchName = "InsertDeleteReplaceEditTypes.patch";
+    public void testMultiHunksOnSingleFile() throws Exception {
+        final String patchName = "MultiHunksOnOneFile.patch";
         final Patch patch = loadPatch(getPatchPath(patchName));
         assertNotNull(patch);
 
@@ -47,16 +47,14 @@ public class GitDiffWithContextSizeDefaultTest extends AbstractJgitPatchParserEv
 
         // file header 0
         assertEquals(FileHeader.PatchType.UNIFIED, fileHeaders.get(0).getPatchType());
-        assertEquals(1, fileHeaders.get(0).getHunks().size());
+        assertEquals(2, fileHeaders.get(0).getHunks().size());
 
         final EditList edits = fileHeaders.get(0).toEditList();
-        assertEquals(3, edits.size());
-        assertEquals(new Edit(17, 17, 17, 18), edits.get(0));
+        assertEquals(2, edits.size());
+        assertEquals(new Edit(4, 4, 4, 12), edits.get(0));
         assertEquals(Edit.Type.INSERT, edits.get(0).getType());
-        assertEquals(new Edit(20, 21, 21, 22), edits.get(1));
-        assertEquals(Edit.Type.REPLACE, edits.get(1).getType());
-        assertEquals(new Edit(23, 24, 24, 24), edits.get(2));
-        assertEquals(Edit.Type.DELETE, edits.get(2).getType());
+        assertEquals(new Edit(17, 17, 25, 27), edits.get(1));
+        assertEquals(Edit.Type.INSERT, edits.get(1).getType());
     }
 
     @Test
@@ -89,6 +87,142 @@ public class GitDiffWithContextSizeDefaultTest extends AbstractJgitPatchParserEv
         assertEquals(Edit.Type.INSERT, edits1.get(0).getType());
         assertEquals(new Edit(17, 17, 25, 27), edits1.get(1));
         assertEquals(Edit.Type.INSERT, edits1.get(1).getType());
+    }
+
+    @Test
+    public void testHaveRenamedWithNoChangedFile() throws Exception {
+        final String patchName = "HaveRenamedFile.patch";
+        final Patch patch = loadPatch(getPatchPath(patchName));
+        assertNotNull(patch);
+
+        final List<? extends FileHeader> fileHeaders = patch.getFiles();
+        assertEquals(1, fileHeaders.size());
+
+        // file header 0
+        assertEquals(FileHeader.PatchType.UNIFIED, fileHeaders.get(0).getPatchType());
+        assertEquals(0, fileHeaders.get(0).getHunks().size());
+        assertEquals("RENAME", fileHeaders.get(0).getChangeType().name());
+
+    }
+
+    @Test
+    public void testHaveRemovedFile() throws Exception {
+        final String patchName = "HaveRemovedFile.patch";
+        final Patch patch = loadPatch(getPatchPath(patchName));
+        assertNotNull(patch);
+
+        final List<? extends FileHeader> fileHeaders = patch.getFiles();
+        assertEquals(1, fileHeaders.size());
+
+        // file header 0
+        assertEquals(FileHeader.PatchType.UNIFIED, fileHeaders.get(0).getPatchType());
+        assertEquals(1, fileHeaders.get(0).getHunks().size());
+
+        final EditList edits0 = fileHeaders.get(0).toEditList();
+        assertEquals(1, edits0.size());
+        assertEquals(new Edit(0, 23, -1, -1), edits0.get(0));
+        assertEquals(Edit.Type.DELETE, edits0.get(0).getType());
+    }
+
+    @Test
+    public void testMovedCodeInOneFileZeroSize() throws Exception {
+        final String patchName = "MovedCodeInOneFile.patch";
+        final Patch patch = loadPatch(getPatchPath(patchName));
+        assertNotNull(patch);
+
+        final List<? extends FileHeader> fileHeaders = patch.getFiles();
+        assertEquals(1, fileHeaders.size());
+
+        // file header 0
+        assertEquals(FileHeader.PatchType.UNIFIED, fileHeaders.get(0).getPatchType());
+        assertEquals(2, fileHeaders.get(0).getHunks().size());
+
+        final EditList edits0 = fileHeaders.get(0).toEditList();
+        assertEquals(2, edits0.size());
+        assertEquals(new Edit(5, 12, 5, 5), edits0.get(0));
+        assertEquals(Edit.Type.DELETE, edits0.get(0).getType());
+        assertEquals(new Edit(28, 28, 21, 29), edits0.get(1));
+        assertEquals(Edit.Type.INSERT, edits0.get(1).getType());
+    }
+
+    @Test
+    public void testOnlyDeletionInOneFile() throws Exception {
+        final String patchName = "OnlyDeletionInOneFile.patch";
+        final Patch patch = loadPatch(getPatchPath(patchName));
+        assertNotNull(patch);
+
+        final List<? extends FileHeader> fileHeaders = patch.getFiles();
+        assertEquals(1, fileHeaders.size());
+
+        // file header 0
+        assertEquals(FileHeader.PatchType.UNIFIED, fileHeaders.get(0).getPatchType());
+        assertEquals(1, fileHeaders.get(0).getHunks().size());
+
+        final EditList edits0 = fileHeaders.get(0).toEditList();
+        assertEquals(1, edits0.size());
+        assertEquals(new Edit(21, 29, 21, 21), edits0.get(0));
+        assertEquals(Edit.Type.DELETE, edits0.get(0).getType());
+    }
+
+    @Test
+    public void testOnlyAdditionInOneFile() throws Exception {
+        final String patchName = "OnlyAdditionInOneFile.patch";
+        final Patch patch = loadPatch(getPatchPath(patchName));
+        assertNotNull(patch);
+
+        final List<? extends FileHeader> fileHeaders = patch.getFiles();
+        assertEquals(1, fileHeaders.size());
+
+        // file header 0
+        assertEquals(FileHeader.PatchType.UNIFIED, fileHeaders.get(0).getPatchType());
+        assertEquals(1, fileHeaders.get(0).getHunks().size());
+
+        final EditList edits0 = fileHeaders.get(0).toEditList();
+        assertEquals(1, edits0.size());
+        assertEquals(new Edit(20, 20, 20, 24), edits0.get(0));
+        assertEquals(Edit.Type.INSERT, edits0.get(0).getType());
+    }
+
+    @Test
+    public void testOnlyReplacementInOneFile() throws Exception {
+        final String patchName = "OnlyReplaceMentInOneFile.patch";
+        final Patch patch = loadPatch(getPatchPath(patchName));
+        assertNotNull(patch);
+
+        final List<? extends FileHeader> fileHeaders = patch.getFiles();
+        assertEquals(1, fileHeaders.size());
+
+        // file header 0
+        assertEquals(FileHeader.PatchType.UNIFIED, fileHeaders.get(0).getPatchType());
+        assertEquals(1, fileHeaders.get(0).getHunks().size());
+
+        final EditList edits0 = fileHeaders.get(0).toEditList();
+        assertEquals(1, edits0.size());
+        assertEquals(new Edit(20, 22, 20, 22), edits0.get(0));
+        assertEquals(Edit.Type.REPLACE, edits0.get(0).getType());
+    }
+
+    @Test
+    public void testInsertDeleteReplaceEditTypesWithinHunk() throws IOException {
+        final String patchName = "InsertDeleteReplaceEditTypes.patch";
+        final Patch patch = loadPatch(getPatchPath(patchName));
+        assertNotNull(patch);
+
+        final List<? extends FileHeader> fileHeaders = patch.getFiles();
+        assertEquals(1, fileHeaders.size());
+
+        // file header 0
+        assertEquals(FileHeader.PatchType.UNIFIED, fileHeaders.get(0).getPatchType());
+        assertEquals(1, fileHeaders.get(0).getHunks().size());
+
+        final EditList edits = fileHeaders.get(0).toEditList();
+        assertEquals(3, edits.size());
+        assertEquals(new Edit(17, 17, 17, 18), edits.get(0));
+        assertEquals(Edit.Type.INSERT, edits.get(0).getType());
+        assertEquals(new Edit(20, 21, 21, 22), edits.get(1));
+        assertEquals(Edit.Type.REPLACE, edits.get(1).getType());
+        assertEquals(new Edit(23, 24, 24, 24), edits.get(2));
+        assertEquals(Edit.Type.DELETE, edits.get(2).getType());
     }
 
     @Override

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/HaveRemovedFile.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/HaveRemovedFile.patch
@@ -1,0 +1,29 @@
+diff --git a/src/main/java/Test2.java b/src/main/java/Test2.java
+deleted file mode 100644
+index aba6949..0000000
+--- a/src/main/java/Test2.java
++++ /dev/null
+@@ -1,23 +0,0 @@
+-public class Test2 {
+-    public void test1() {
+-
+-    }
+-
+-    public void test2() {
+-
+-    }
+-
+-    public void test3() {
+-
+-    }
+-}
+-
+-
+-
+-class Test22 {
+-    public void test1() {
+-        System.out.println();
+-        System.out.println();
+-        System.out.println();
+-    }
+-}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/HaveRenamedFile.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/HaveRenamedFile.patch
@@ -1,0 +1,4 @@
+diff --git a/src/main/java/Test3.java b/src/main/java/Test.java
+similarity index 100%
+rename from src/main/java/Test3.java
+rename to src/main/java/Test.java

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/MovedCodeInOneFile.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/MovedCodeInOneFile.patch
@@ -1,0 +1,31 @@
+diff --git a/src/main/java/Test1.java b/src/main/java/Test1.java
+index aeb4c5d..20770b4 100644
+--- a/src/main/java/Test1.java
++++ b/src/main/java/Test1.java
+@@ -3,13 +3,6 @@ public class Test1 {
+ 
+     }
+ 
+-    public void test2() {
+-
+-    }
+-
+-    public void test3() {
+-
+-    }
+ }
+ 
+ 
+@@ -26,4 +19,12 @@ class Test {
+         System.out.println();
+         System.out.println();
+     }
++
++    public void test2() {
++
++    }
++
++    public void test3() {
++
++    }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/MultiHunksOnOneFile.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/MultiHunksOnOneFile.patch
@@ -1,0 +1,27 @@
+diff --git a/src/main/java/Test1.java b/src/main/java/Test1.java
+index 90363f8..aeb4c5d 100644
+--- a/src/main/java/Test1.java
++++ b/src/main/java/Test1.java
+@@ -2,6 +2,14 @@ public class Test1 {
+     public void test1() {
+ 
+     }
++
++    public void test2() {
++
++    }
++
++    public void test3() {
++
++    }
+ }
+ 
+ 
+@@ -15,5 +23,7 @@ public class Test1 {
+ class Test {
+     public void test1() {
+         System.out.println();
++        System.out.println();
++        System.out.println();
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/OnlyAdditionInOneFile.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/OnlyAdditionInOneFile.patch
@@ -1,0 +1,14 @@
+diff --git a/src/main/java/Test1.java b/src/main/java/Test1.java
+index 69f0e2b..13e0ba1 100644
+--- a/src/main/java/Test1.java
++++ b/src/main/java/Test1.java
+@@ -18,5 +18,9 @@ class Test {
+         System.out.println();
+         System.out.println();
+         System.out.println();
++        System.out.println();
++        System.out.println();
++        System.out.println();
++        System.out.println();
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/OnlyDeletionInOneFile.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/OnlyDeletionInOneFile.patch
@@ -1,0 +1,17 @@
+diff --git a/src/main/java/Test1.java b/src/main/java/Test1.java
+index 20770b4..69f0e2b 100644
+--- a/src/main/java/Test1.java
++++ b/src/main/java/Test1.java
+@@ -19,12 +19,4 @@ class Test {
+         System.out.println();
+         System.out.println();
+     }
+-
+-    public void test2() {
+-
+-    }
+-
+-    public void test3() {
+-
+-    }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/OnlyReplaceMentInOneFile.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/jgit/gitdiff/context-size-default/OnlyReplaceMentInOneFile.patch
@@ -1,0 +1,15 @@
+diff --git a/src/main/java/Test1.java b/src/main/java/Test1.java
+index 13e0ba1..5b222c5 100644
+--- a/src/main/java/Test1.java
++++ b/src/main/java/Test1.java
+@@ -18,8 +18,8 @@ class Test {
+         System.out.println();
+         System.out.println();
+         System.out.println();
+-        System.out.println();
+-        System.out.println();
++        System.out.println("test1");
++        System.out.println("test2");
+         System.out.println();
+         System.out.println();
+     }


### PR DESCRIPTION
Issue #76: Add unit tests to evaluate jgit patch parser (GitDiffCommandDefaultSize)

> Patch is generated via diff -Naru <file1/dir1> <file2/dir2> (using default context size) - Pull Request 1