### PR TITLE
Issue #92: Add Non-Treewalker filter tests to cover more cases(FileTabCharacter)

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterTest.java
@@ -260,6 +260,114 @@ public class SuppressionPatchFilterTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testFileTabCharacterMoveCodeInSameFileWithoutChanges() throws Exception {
+        final String inputFile =
+                "strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/Test.java";
+
+        final String defaultContextConfigPathOne =
+                "strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/"
+                        + "newline/defaultContextConfig.xml";
+        final String zeroContextConfigPathOne =
+                "strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/"
+                        + "newline/zeroContextConfig.xml";
+        final String[] expectedOne = {
+            "19:25: Line contains a tab character.",
+        };
+        testByConfig(defaultContextConfigPathOne, inputFile, expectedOne);
+        testByConfig(zeroContextConfigPathOne, inputFile, expectedOne);
+
+        final String defaultContextConfigPathTwo =
+                "strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges"
+                        + "/patchedline/defaultContextConfig.xml";
+        final String zeroContextConfigPathTwo =
+                "strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/"
+                        + "patchedline/zeroContextConfig.xml";
+        final String[] expectedTwo = {
+            "19:25: Line contains a tab character.",
+        };
+        testByConfig(defaultContextConfigPathTwo, inputFile, expectedTwo);
+        testByConfig(zeroContextConfigPathTwo, inputFile, expectedTwo);
+    }
+
+    @Test
+    public void testFileTabCharacterMoveCodeInSameFileWithMinorChanges() throws Exception {
+        final String inputFile =
+                "strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/Test.java";
+
+        final String defaultContextConfigPathOne =
+                "strategy/FileTabCharacter/"
+                        + "MoveCodeInSameFileWithMinorChanges/newline/defaultContextConfig.xml";
+        final String zeroContextConfigPathOne =
+                "strategy/FileTabCharacter/"
+                        + "MoveCodeInSameFileWithMinorChanges/newline/zeroContextConfig.xml";
+        final String[] expectedOne = {
+            "19:25: Line contains a tab character.",
+        };
+        testByConfig(defaultContextConfigPathOne, inputFile, expectedOne);
+        testByConfig(zeroContextConfigPathOne, inputFile, expectedOne);
+
+        final String defaultContextConfigPathTwo =
+                "strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges"
+                        + "/patchedline/defaultContextConfig.xml";
+        final String zeroContextConfigPathTwo =
+                "strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges"
+                        + "/patchedline/zeroContextConfig.xml";
+        final String[] expectedTwo = {
+            "19:25: Line contains a tab character.",
+        };
+        testByConfig(defaultContextConfigPathTwo, inputFile, expectedTwo);
+        testByConfig(zeroContextConfigPathTwo, inputFile, expectedTwo);
+    }
+
+    @Test
+    public void testFileTabCharacterSingleChangedLine() throws Exception {
+        final String inputFile = "strategy/FileTabCharacter/SingleChangedLine/Test.java";
+
+        final String defaultContextConfigPathOne =
+                "strategy/FileTabCharacter/SingleChangedLine/newline/defaultContextConfig.xml";
+        final String zeroContextConfigPathOne =
+                "strategy/FileTabCharacter/SingleChangedLine/newline/zeroContextConfig.xml";
+        final String[] expectedOne = {};
+        testByConfig(defaultContextConfigPathOne, inputFile, expectedOne);
+        testByConfig(zeroContextConfigPathOne, inputFile, expectedOne);
+
+        final String defaultContextConfigPathTwo =
+                "strategy/FileTabCharacter/SingleChangedLine/patchedline/defaultContextConfig.xml";
+        final String zeroContextConfigPathTwo =
+                "strategy/FileTabCharacter/SingleChangedLine/patchedline/zeroContextConfig.xml";
+        final String[] expectedTwo = {
+            "19:25: Line contains a tab character.",
+        };
+        testByConfig(defaultContextConfigPathTwo, inputFile, expectedTwo);
+        testByConfig(zeroContextConfigPathTwo, inputFile, expectedTwo);
+    }
+
+    @Test
+    public void testFileTabCharacterSingleNewLine() throws Exception {
+        final String inputFile = "strategy/FileTabCharacter/SingleNewLine/Test.java";
+
+        final String defaultContextConfigPathOne =
+                "strategy/FileTabCharacter/SingleNewLine/newline/defaultContextConfig.xml";
+        final String zeroContextConfigPathOne =
+                "strategy/FileTabCharacter/SingleNewLine/newline/zeroContextConfig.xml";
+        final String[] expectedOne = {
+            "20:25: Line contains a tab character.",
+        };
+        testByConfig(defaultContextConfigPathOne, inputFile, expectedOne);
+        testByConfig(zeroContextConfigPathOne, inputFile, expectedOne);
+
+        final String defaultContextConfigPathTwo =
+                "strategy/FileTabCharacter/SingleNewLine/patchedline/defaultContextConfig.xml";
+        final String zeroContextConfigPathTwo =
+                "strategy/FileTabCharacter/SingleNewLine/patchedline/zeroContextConfig.xml";
+        final String[] expectedTwo = {
+            "20:25: Line contains a tab character.",
+        };
+        testByConfig(defaultContextConfigPathTwo, inputFile, expectedTwo);
+        testByConfig(zeroContextConfigPathTwo, inputFile, expectedTwo);
+    }
+
+    @Test
     @Ignore("until https://github.com/checkstyle/patch-filters/issues/88 "
             + "when testByConfig can process a directory contains more than one file")
     public void testRegexpOnFilename() throws Exception {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/Test.java
@@ -1,0 +1,24 @@
+package Checker.FileTabCharacter;
+
+public class Test {
+    // Long line ----------------------------------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<- //warns  // violation newline/patchedline
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<- //warns
+
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/defaultContext.patch
@@ -1,0 +1,20 @@
+diff --git a/Test.java b/Test.java
+index aea01e2..5982414 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,7 +2,6 @@ package Checker.FileTabCharacter;
+ 
+ public class Test {
+     // Long line ----------------------------------------------------------------
+-    // Contains a tab ->	<- //warn
+ 
+ 
+ 
+@@ -17,6 +16,7 @@ public class Test {
+ 
+ 
+     // Long line ----------------------------------------------------------------
++    // Contains a tab ->	<- //warns
+     // Long line ----------------------------------------------------------------
+     // Contains a tab ->	<- //warns
+ 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/newline/defaultContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/defaultContext.patch" />
+    <property name="strategy" value="newline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/newline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/newline/zeroContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/zeroContext.patch" />
+    <property name="strategy" value="newline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/patchedline/defaultContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/defaultContext.patch" />
+    <property name="strategy" value="patchedline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/patchedline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/patchedline/zeroContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/zeroContext.patch" />
+    <property name="strategy" value="patchedline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/zeroContext.patch
@@ -1,0 +1,8 @@
+diff --git a/Test.java b/Test.java
+index aea01e2..5982414 100644
+--- a/Test.java
++++ b/Test.java
+@@ -5 +4,0 @@ public class Test {
+-    // Contains a tab ->	<- //warn
+@@ -19,0 +19 @@ public class Test {
++    // Contains a tab ->	<- //warns

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/Test.java
@@ -1,0 +1,24 @@
+package Checker.FileTabCharacter;
+
+public class Test {
+    // Long line ----------------------------------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<- //warn  // violation newline/patchedline
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<- //warns
+
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/defaultContext.patch
@@ -1,0 +1,20 @@
+diff --git a/Test.java b/Test.java
+index aea01e2..5982414 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,7 +2,6 @@ package Checker.FileTabCharacter;
+ 
+ public class Test {
+     // Long line ----------------------------------------------------------------
+-    // Contains a tab ->	<- //warn
+ 
+ 
+ 
+@@ -17,6 +16,7 @@ public class Test {
+ 
+ 
+     // Long line ----------------------------------------------------------------
++    // Contains a tab ->	<- //warn
+     // Long line ----------------------------------------------------------------
+     // Contains a tab ->	<- //warns
+ 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/newline/defaultContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/defaultContext.patch" />
+    <property name="strategy" value="newline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/newline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/newline/zeroContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/zeroContext.patch" />
+    <property name="strategy" value="newline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/patchedline/defaultContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/defaultContext.patch" />
+    <property name="strategy" value="patchedline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/patchedline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/patchedline/zeroContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/zeroContext.patch" />
+    <property name="strategy" value="patchedline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/MoveCodeInSameFileWithoutChanges/zeroContext.patch
@@ -1,0 +1,8 @@
+diff --git a/Test.java b/Test.java
+index aea01e2..5982414 100644
+--- a/Test.java
++++ b/Test.java
+@@ -5 +4,0 @@ public class Test {
+-    // Contains a tab ->	<- //warn
+@@ -19,0 +19 @@ public class Test {
++    // Contains a tab ->	<- //warn

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/Test.java
@@ -1,0 +1,24 @@
+package Checker.FileTabCharacter;
+
+public class Test {
+    // Long line ----------------------------------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<- //warn  // violation patchedline
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<- //warns
+
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/defaultContext.patch
@@ -1,0 +1,13 @@
+diff --git a/Test.java b/Test.java
+index 404df53..5982414 100644
+--- a/Test.java
++++ b/Test.java
+@@ -16,7 +16,7 @@ public class Test {
+ 
+ 
+     // Long line ----------------------------------------------------------------
+-    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warn
+     // Long line ----------------------------------------------------------------
+     // Contains a tab ->	<- //warns
+ 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/newline/defaultContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/defaultContext.patch" />
+    <property name="strategy" value="newline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/newline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/newline/zeroContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/zeroContext.patch" />
+    <property name="strategy" value="newline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/patchedline/defaultContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/defaultContext.patch" />
+    <property name="strategy" value="patchedline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/patchedline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/patchedline/zeroContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/zeroContext.patch" />
+    <property name="strategy" value="patchedline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleChangedLine/zeroContext.patch
@@ -1,0 +1,7 @@
+diff --git a/Test.java b/Test.java
+index 404df53..5982414 100644
+--- a/Test.java
++++ b/Test.java
+@@ -19 +19 @@ public class Test {
+-    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warn

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/Test.java
@@ -1,0 +1,25 @@
+package Checker.FileTabCharacter;
+
+public class Test {
+    // Long line ----------------------------------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<- //warn
+    // Contains a tab ->	<- //warn  // violation newline/patchedline
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<- //warns
+
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 5982414..7dd3e99 100644
+--- a/Test.java
++++ b/Test.java
+@@ -17,6 +17,7 @@ public class Test {
+ 
+     // Long line ----------------------------------------------------------------
+     // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn
+     // Long line ----------------------------------------------------------------
+     // Contains a tab ->	<- //warns
+ 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/newline/defaultContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/defaultContext.patch" />
+    <property name="strategy" value="newline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/newline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/newline/zeroContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/zeroContext.patch" />
+    <property name="strategy" value="newline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/patchedline/defaultContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/defaultContext.patch" />
+    <property name="strategy" value="patchedline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/patchedline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/patchedline/zeroContextConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+    <property name="file" value="src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/zeroContext.patch" />
+    <property name="strategy" value="patchedline" />
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/strategy/FileTabCharacter/SingleNewLine/zeroContext.patch
@@ -1,0 +1,6 @@
+diff --git a/Test.java b/Test.java
+index 5982414..7dd3e99 100644
+--- a/Test.java
++++ b/Test.java
+@@ -19,0 +20 @@ public class Test {
++    // Contains a tab ->	<- //warn


### PR DESCRIPTION
Issue #92: Add Non-Treewalker filter tests to cover more cases(FileTabCharacter)

use case: 1, 2 have not finished until https://github.com/checkstyle/patch-filters/issues/88

use case 3, 4, 5, 6 have finished.