### PR TITLE
Issue #7: add example for MethodLength

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -122,4 +122,21 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
         testByConfig(
                 "MemberName/patchedline/defaultContextConfig.xml");
     }
+
+    @Test
+    @Ignore("MethodLength should have a violation when method length"
+            + " is more than threshold, but not. It should be solved by"
+            + "context strategy.")
+    public void testMethodLengthContextStrategy() throws Exception {
+        testByConfig(
+                "MethodLength/contexttwo/defaultContextConfig.xml");
+    }
+
+    @Test
+    @Ignore("MethodLength should have no violations after patching,"
+            + " but should show violations before patching.")
+    public void testMethodLengthViolationShouldBeSuppressedAfterPatch() throws Exception {
+        testByConfig(
+                "MethodLength/context/defaultContextConfig.xml");
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/context/Test.java
@@ -1,0 +1,8 @@
+public class Test {
+    private String name;
+
+    public void test() { // violation context, should be suppressed after patching
+        int a = 123;
+        int b = 234;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/context/defaultContext.patch
@@ -1,0 +1,11 @@
+diff --git a/Test.java b/Test.java
+index d85e94c..bcd3588 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,4 +1,6 @@
+ public class Test {
++    private String name;
++
+     public void test() {
+         int a = 123;
+         int b = 234;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/context/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MethodLength">
+            <property name="max" value="3"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/contexttwo/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/contexttwo/Test.java
@@ -1,0 +1,7 @@
+public class Test {
+    public void test() { // violation context
+        int a = 123;
+        int b = 234;
+        int c = 345;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/contexttwo/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/contexttwo/defaultContext.patch
@@ -1,0 +1,11 @@
+diff --git a/Test.java b/Test.java
+index d85e94c..db1f8c2 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,6 +2,7 @@ public class Test {
+     public void test() {
+         int a = 123;
+         int b = 234;
++        int c = 345;
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/contexttwo/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/contexttwo/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MethodLength">
+            <property name="max" value="3"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/contexttwo/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/contexttwo/expected.txt
@@ -1,0 +1,1 @@
+Test.java:2:5: Method length is 5 lines (max allowed is 3). [MethodLength]


### PR DESCRIPTION
https://github.com/checkstyle/patch-filters/issues/7

Demonstration of the case, when violations should be thrown only before patching and should be suppressed after