### PR TITLE
minor: all Input files should have 'violation' comment/word on line where it is before filtering

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/Test.java
@@ -1,4 +1,4 @@
-package Checker.FileLength;
+package Checker.FileLength; // violation
 
 public class Test {
     public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/Test2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/Test2.java
@@ -1,4 +1,4 @@
-package Checker.FileLength;  // violation newline/patchedline
+package Checker.FileLength; // violation newline/patchedline
 
 public class Test2 {
     public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/defaultContext.patch
@@ -15,7 +15,7 @@ index 0000000..67782f7
 --- /dev/null
 +++ b/Test2.java
 @@ -0,0 +1,14 @@
-+package Checker.FileLength;
++package Checker.FileLength; // violation
 +
 +public class Test2 {
 +    public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/zeroContext.patch
@@ -10,7 +10,7 @@ index 0000000..67782f7
 --- /dev/null
 +++ b/Test2.java
 @@ -0,0 +1,14 @@
-+package Checker.FileLength;
++package Checker.FileLength; // violation newline/patchedline
 +
 +public class Test2 {
 +    public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/Test.java
@@ -1,4 +1,4 @@
-package Checker.FileLength;
+package Checker.FileLength; // violation
 
 public class Test {
     public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/defaultContext.patch
@@ -15,7 +15,7 @@ index 0000000..67782f7
 --- /dev/null
 +++ b/Test2.java
 @@ -0,0 +1,14 @@
-+package Checker.FileLength;
++package Checker.FileLength; // violation
 +
 +public class Test2 {
 +    public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/zeroContext.patch
@@ -10,7 +10,7 @@ index 0000000..67782f7
 --- /dev/null
 +++ b/Test2.java
 @@ -0,0 +1,14 @@
-+package Checker.FileLength;
++package Checker.FileLength; // violation newline/patchedline
 +
 +public class Test2 {
 +    public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/newline/defaultContext.patch
@@ -14,7 +14,6 @@ index aea01e2..5982414 100644
  
  
      // Long line ----------------------------------------------------------------
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns  // violation newline/patchedline
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warns
- 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/newline/zeroContext.patch
@@ -5,4 +5,4 @@ index aea01e2..5982414 100644
 @@ -5 +4,0 @@ public class Test {
 -    // Contains a tab ->	<- //warn
 @@ -19,0 +19 @@ public class Test {
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/patchedline/defaultContext.patch
@@ -14,7 +14,6 @@ index aea01e2..5982414 100644
  
  
      // Long line ----------------------------------------------------------------
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns  // violation newline/patchedline
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warns
- 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithMinorChanges/patchedline/zeroContext.patch
@@ -5,4 +5,4 @@ index aea01e2..5982414 100644
 @@ -5 +4,0 @@ public class Test {
 -    // Contains a tab ->	<- //warn
 @@ -19,0 +19 @@ public class Test {
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithoutChanges/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithoutChanges/newline/defaultContext.patch
@@ -14,7 +14,7 @@ index aea01e2..5982414 100644
  
  
      // Long line ----------------------------------------------------------------
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation newline/patchedline
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warns
  

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithoutChanges/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithoutChanges/newline/zeroContext.patch
@@ -5,4 +5,4 @@ index aea01e2..5982414 100644
 @@ -5 +4,0 @@ public class Test {
 -    // Contains a tab ->	<- //warn
 @@ -19,0 +19 @@ public class Test {
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithoutChanges/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithoutChanges/patchedline/defaultContext.patch
@@ -14,7 +14,7 @@ index aea01e2..5982414 100644
  
  
      // Long line ----------------------------------------------------------------
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation newline/patchedline
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warns
  

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithoutChanges/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeInSameFileWithoutChanges/patchedline/zeroContext.patch
@@ -5,4 +5,4 @@ index aea01e2..5982414 100644
 @@ -5 +4,0 @@ public class Test {
 -    // Contains a tab ->	<- //warn
 @@ -19,0 +19 @@ public class Test {
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithMinorChanges/newline/Test2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithMinorChanges/newline/Test2.java
@@ -1,5 +1,5 @@
 package Checker.FileTabCharacter;
 
 public class Test2 {
-    // Contains a tab ->	<- //warns
+    // Contains a tab ->	<- //warns // violation newline/patchedline
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithMinorChanges/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithMinorChanges/newline/defaultContext.patch
@@ -18,5 +18,5 @@ index 6055de3..b4ea012 100644
  package Checker.FileTabCharacter;
  
  public class Test2 {
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns // violation newline/patchedline
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithMinorChanges/patchedline/Test2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithMinorChanges/patchedline/Test2.java
@@ -1,5 +1,5 @@
 package Checker.FileTabCharacter;
 
 public class Test2 {
-    // Contains a tab ->	<- //warns
+    // Contains a tab ->	<- //warns // violation newline/patchedline
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithMinorChanges/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithMinorChanges/patchedline/defaultContext.patch
@@ -18,5 +18,5 @@ index 6055de3..b4ea012 100644
  package Checker.FileTabCharacter;
  
  public class Test2 {
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns // violation newline/patchedline
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithoutChanges/newline/Test2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithoutChanges/newline/Test2.java
@@ -1,5 +1,5 @@
 package Checker.FileTabCharacter;
 
 public class Test2 {
-    // Contains a tab ->	<- //warn
+    // Contains a tab ->	<- //warn // violation newline/patchedline
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithoutChanges/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithoutChanges/newline/defaultContext.patch
@@ -18,5 +18,5 @@ index 6055de3..ec9471a 100644
  package Checker.FileTabCharacter;
  
  public class Test2 {
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn // violation newline/patchedline
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithoutChanges/patchedline/Test2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithoutChanges/patchedline/Test2.java
@@ -1,5 +1,5 @@
 package Checker.FileTabCharacter;
 
 public class Test2 {
-    // Contains a tab ->	<- //warn
+    // Contains a tab ->	<- //warn // violation newline/patchedline
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithoutChanges/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/MoveCodeToAnotherFileWithoutChanges/patchedline/defaultContext.patch
@@ -18,5 +18,5 @@ index 6055de3..ec9471a 100644
  package Checker.FileTabCharacter;
  
  public class Test2 {
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn // violation newline/patchedline
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleChangedLine/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleChangedLine/newline/defaultContext.patch
@@ -7,7 +7,7 @@ index 404df53..5982414 100644
  
      // Long line ----------------------------------------------------------------
 -    // Contains a tab ->	<- //warns
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation patchedline
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warns
  

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleChangedLine/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleChangedLine/newline/zeroContext.patch
@@ -4,4 +4,4 @@ index 404df53..5982414 100644
 +++ b/Test.java
 @@ -19 +19 @@ public class Test {
 -    // Contains a tab ->	<- //warns
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleChangedLine/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleChangedLine/patchedline/defaultContext.patch
@@ -7,7 +7,7 @@ index 404df53..5982414 100644
  
      // Long line ----------------------------------------------------------------
 -    // Contains a tab ->	<- //warns
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation patchedline
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warns
  

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleChangedLine/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleChangedLine/patchedline/zeroContext.patch
@@ -4,4 +4,4 @@ index 404df53..5982414 100644
 +++ b/Test.java
 @@ -19 +19 @@ public class Test {
 -    // Contains a tab ->	<- //warns
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleNewLine/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleNewLine/newline/defaultContext.patch
@@ -6,7 +6,7 @@ index 5982414..7dd3e99 100644
  
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warn
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation newline/patchedline
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warns
  

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleNewLine/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleNewLine/newline/zeroContext.patch
@@ -3,4 +3,4 @@ index 5982414..7dd3e99 100644
 --- a/Test.java
 +++ b/Test.java
 @@ -19,0 +20 @@ public class Test {
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleNewLine/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleNewLine/patchedline/defaultContext.patch
@@ -6,7 +6,7 @@ index 5982414..7dd3e99 100644
  
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warn
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation newline/patchedline
      // Long line ----------------------------------------------------------------
      // Contains a tab ->	<- //warns
  

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleNewLine/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/SingleNewLine/patchedline/zeroContext.patch
@@ -3,4 +3,4 @@ index 5982414..7dd3e99 100644
 --- a/Test.java
 +++ b/Test.java
 @@ -19,0 +20 @@ public class Test {
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/newline/defaultContext.patch
@@ -7,7 +7,7 @@ index 6730df1..aea01e2 100644
  public class Test {
      // Long line ----------------------------------------------------------------
 -    // Contains a tab ->	<- //warns
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation patchedline
  
  
  
@@ -15,7 +15,7 @@ index 6730df1..aea01e2 100644
  
      // Long line ----------------------------------------------------------------
      // Long line ----------------------------------------------------------------
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns  // violation newline/patchedline
  
  
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/newline/zeroContext.patch
@@ -4,6 +4,6 @@ index 6730df1..aea01e2 100644
 +++ b/Test.java
 @@ -5 +5 @@ public class Test {
 -    // Contains a tab ->	<- //warns
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation patchedline
 @@ -20,0 +21 @@ public class Test {
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/patchedline/defaultContext.patch
@@ -7,7 +7,7 @@ index 6730df1..aea01e2 100644
  public class Test {
      // Long line ----------------------------------------------------------------
 -    // Contains a tab ->	<- //warns
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation patchedline
  
  
  
@@ -15,7 +15,7 @@ index 6730df1..aea01e2 100644
  
      // Long line ----------------------------------------------------------------
      // Long line ----------------------------------------------------------------
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns  // violation newline/patchedline
  
  
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileTabCharacter/patchedline/zeroContext.patch
@@ -4,6 +4,6 @@ index 6730df1..aea01e2 100644
 +++ b/Test.java
 @@ -5 +5 @@ public class Test {
 -    // Contains a tab ->	<- //warns
-+    // Contains a tab ->	<- //warn
++    // Contains a tab ->	<- //warn  // violation patchedline
 @@ -20,0 +21 @@ public class Test {
-+    // Contains a tab ->	<- //warns
++    // Contains a tab ->	<- //warns  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/LineLength/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/LineLength/newline/defaultContext.patch
@@ -12,6 +12,6 @@ index 5108b81..f6e3b37 100644
          System.out.println();
          System.out.println();
          System.out.println();
-+        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");
++        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");  // violation newline/patchedline
      }
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/LineLength/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/LineLength/newline/zeroContext.patch
@@ -6,4 +6,4 @@ index 5108b81..f6e3b37 100644
 -        System.out.println("hhhhh");
 +        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");
 @@ -9,0 +10 @@ public class LineLength {
-+        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");
++        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/LineLength/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/LineLength/patchedline/defaultContext.patch
@@ -12,6 +12,6 @@ index 5108b81..f6e3b37 100644
          System.out.println();
          System.out.println();
          System.out.println();
-+        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");
++        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");  // violation newline/patchedline
      }
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/LineLength/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/LineLength/patchedline/zeroContext.patch
@@ -6,4 +6,4 @@ index 5108b81..f6e3b37 100644
 -        System.out.println("hhhhh");
 +        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");
 @@ -9,0 +10 @@ public class LineLength {
-+        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");
++        System.out.println("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/Test2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/Test2.java
@@ -1,4 +1,4 @@
-package Checker.NewlineAtEndOfFile;
+package Checker.NewlineAtEndOfFile;  // violation context
 
 public class Test2 {
     public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/defaultContext.patch
@@ -4,7 +4,7 @@ index 3d4cda6..bb20409 100644
 +++ b/Test.java
 @@ -1,4 +1,4 @@
 -package Checker.NewlineAtEndOfFile;
-+package Checker.NewlineAtEndOfFiles;
++package Checker.NewlineAtEndOfFiles;  // violation patchedline
  
  public class Test {
  }
@@ -14,7 +14,7 @@ index 5e458a8..898b639 100644
 --- a/Test2.java
 +++ b/Test2.java
 @@ -1,4 +1,7 @@
- package Checker.NewlineAtEndOfFile;
+ package Checker.NewlineAtEndOfFile;  // violation context
  
  public class Test2 {
 +    public static void main(String[] args) {
@@ -28,7 +28,7 @@ index 0000000..0047b33
 --- /dev/null
 +++ b/Test3.java
 @@ -0,0 +1,4 @@
-+package Checker.NewlineAtEndOfFile;
++package Checker.NewlineAtEndOfFile;  // violation newline/patchedline
 +
 +public class Test3 {
 +}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/zeroContext.patch
@@ -4,7 +4,7 @@ index 3d4cda6..bb20409 100644
 +++ b/Test.java
 @@ -1 +1 @@
 -package Checker.NewlineAtEndOfFile;
-+package Checker.NewlineAtEndOfFiles;
++package Checker.NewlineAtEndOfFiles;  // violation patchedline
 diff --git a/Test2.java b/Test2.java
 index 5e458a8..898b639 100644
 --- a/Test2.java
@@ -19,7 +19,7 @@ index 0000000..0047b33
 --- /dev/null
 +++ b/Test3.java
 @@ -0,0 +1,4 @@
-+package Checker.NewlineAtEndOfFile;
++package Checker.NewlineAtEndOfFile;  // violation newline/patchedline
 +
 +public class Test3 {
 +}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/Test2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/Test2.java
@@ -1,4 +1,4 @@
-package Checker.NewlineAtEndOfFile;
+package Checker.NewlineAtEndOfFile;  // violation context
 
 public class Test2 {
     public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/defaultContext.patch
@@ -4,7 +4,7 @@ index 3d4cda6..bb20409 100644
 +++ b/Test.java
 @@ -1,4 +1,4 @@
 -package Checker.NewlineAtEndOfFile;
-+package Checker.NewlineAtEndOfFiles;
++package Checker.NewlineAtEndOfFiles;  // violation patchedline
  
  public class Test {
  }
@@ -14,7 +14,7 @@ index 5e458a8..898b639 100644
 --- a/Test2.java
 +++ b/Test2.java
 @@ -1,4 +1,7 @@
- package Checker.NewlineAtEndOfFile;
+ package Checker.NewlineAtEndOfFile;  // violation
  
  public class Test2 {
 +    public static void main(String[] args) {
@@ -28,7 +28,7 @@ index 0000000..0047b33
 --- /dev/null
 +++ b/Test3.java
 @@ -0,0 +1,4 @@
-+package Checker.NewlineAtEndOfFile;
++package Checker.NewlineAtEndOfFile;  // violation newline/patchedline
 +
 +public class Test3 {
 +}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/zeroContext.patch
@@ -4,7 +4,7 @@ index 3d4cda6..bb20409 100644
 +++ b/Test.java
 @@ -1 +1 @@
 -package Checker.NewlineAtEndOfFile;
-+package Checker.NewlineAtEndOfFiles;
++package Checker.NewlineAtEndOfFiles;  // violation patchedline
 diff --git a/Test2.java b/Test2.java
 index 5e458a8..898b639 100644
 --- a/Test2.java
@@ -19,7 +19,7 @@ index 0000000..0047b33
 --- /dev/null
 +++ b/Test3.java
 @@ -0,0 +1,4 @@
-+package Checker.NewlineAtEndOfFile;
++package Checker.NewlineAtEndOfFile;  // violation newline/patchedline
 +
 +public class Test3 {
 +}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/OrderedProperties/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/OrderedProperties/newline/defaultContext.patch
@@ -6,4 +6,4 @@ index e046e89..e46c84e 100644
  key =107 than nothing
  key.sub =k is 107 and dot is 46
  key.png =value - violation
-+key.pag =value - violation
++key.pag =value - violation  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/OrderedProperties/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/OrderedProperties/newline/zeroContext.patch
@@ -3,4 +3,4 @@ index e046e89..e46c84e 100644
 --- a/test.properties
 +++ b/test.properties
 @@ -5,0 +6 @@ key.png =value - violation
-+key.pag =value - violation
++key.pag =value - violation  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/OrderedProperties/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/OrderedProperties/patchedline/defaultContext.patch
@@ -6,4 +6,4 @@ index e046e89..e46c84e 100644
  key =107 than nothing
  key.sub =k is 107 and dot is 46
  key.png =value - violation
-+key.pag =value - violation
++key.pag =value - violation  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/OrderedProperties/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/OrderedProperties/patchedline/zeroContext.patch
@@ -3,4 +3,4 @@ index e046e89..e46c84e 100644
 --- a/test.properties
 +++ b/test.properties
 @@ -5,0 +6 @@ key.png =value - violation
-+key.pag =value - violation
++key.pag =value - violation  // violation newline/patchedline

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/Test2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/Test2.java
@@ -1,4 +1,4 @@
-package Checker.RegexpOnFilename;
+package Checker.RegexpOnFilename;  // violation context
 
 public class Test2 {
     public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/defaultContext.patch
@@ -4,7 +4,7 @@ index 7e1625a..6900690 100644
 +++ b/Test.java
 @@ -1,4 +1,4 @@
 -package Checker.RegexpOnFilename;
-+package Checker.RegexpOnFilenames;
++package Checker.RegexpOnFilenames;  // violation patchedline
  
  public class Test {
  }
@@ -13,7 +13,7 @@ index 1003830..82306c9 100644
 --- a/Test2.java
 +++ b/Test2.java
 @@ -1,4 +1,7 @@
- package Checker.RegexpOnFilename;
+ package Checker.RegexpOnFilename;  // violation context
  
  public class Test2 {
 +    public static void main(String[] args) {
@@ -26,7 +26,7 @@ index 0000000..86748d4
 --- /dev/null
 +++ b/Test3.java
 @@ -0,0 +1,4 @@
-+package Checker.RegexpOnFilename;
++package Checker.RegexpOnFilename;  // violation newline/patchedline
 +
 +public class Test3 {
 +}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/zeroContext.patch
@@ -4,7 +4,7 @@ index 7e1625a..6900690 100644
 +++ b/Test.java
 @@ -1 +1 @@
 -package Checker.RegexpOnFilename;
-+package Checker.RegexpOnFilenames;
++package Checker.RegexpOnFilenames;  // violation patchedline
 diff --git a/Test2.java b/Test2.java
 index 1003830..82306c9 100644
 --- a/Test2.java
@@ -19,7 +19,7 @@ index 0000000..86748d4
 --- /dev/null
 +++ b/Test3.java
 @@ -0,0 +1,4 @@
-+package Checker.RegexpOnFilename;
++package Checker.RegexpOnFilename;  // violation newline/patchedline
 +
 +public class Test3 {
 +}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/Test2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/Test2.java
@@ -1,4 +1,4 @@
-package Checker.RegexpOnFilename;
+package Checker.RegexpOnFilename;  // violation context
 
 public class Test2 {
     public static void main(String[] args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/defaultContext.patch
@@ -4,7 +4,7 @@ index 7e1625a..6900690 100644
 +++ b/Test.java
 @@ -1,4 +1,4 @@
 -package Checker.RegexpOnFilename;
-+package Checker.RegexpOnFilenames;
++package Checker.RegexpOnFilenames;  // violation patchedline
  
  public class Test {
  }
@@ -13,7 +13,7 @@ index 1003830..82306c9 100644
 --- a/Test2.java
 +++ b/Test2.java
 @@ -1,4 +1,7 @@
- package Checker.RegexpOnFilename;
+ package Checker.RegexpOnFilename;  // violation context
  
  public class Test2 {
 +    public static void main(String[] args) {
@@ -26,7 +26,7 @@ index 0000000..86748d4
 --- /dev/null
 +++ b/Test3.java
 @@ -0,0 +1,4 @@
-+package Checker.RegexpOnFilename;
++package Checker.RegexpOnFilename;  // violation newline/patchedline
 +
 +public class Test3 {
 +}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/zeroContext.patch
@@ -4,7 +4,7 @@ index 7e1625a..6900690 100644
 +++ b/Test.java
 @@ -1 +1 @@
 -package Checker.RegexpOnFilename;
-+package Checker.RegexpOnFilenames;
++package Checker.RegexpOnFilenames;  // violation patchedline
 diff --git a/Test2.java b/Test2.java
 index 1003830..82306c9 100644
 --- a/Test2.java
@@ -19,7 +19,7 @@ index 0000000..86748d4
 --- /dev/null
 +++ b/Test3.java
 @@ -0,0 +1,4 @@
-+package Checker.RegexpOnFilename;
++package Checker.RegexpOnFilename;  // violation newline/patchedline
 +
 +public class Test3 {
 +}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Translation/caseOne/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Translation/caseOne/newline/defaultContext.patch
@@ -4,7 +4,7 @@ index 0000000..1593dac
 --- /dev/null
 +++ b/messages_test_de.properties
 @@ -0,0 +1,12 @@
-+# input file for TranslationCheck
++# input file for TranslationCheck  // violation 'only.english' missing
 +
 +# a key that is available in all translations
 +hello=Hallo

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Translation/caseOne/newline/messages_test_de.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Translation/caseOne/newline/messages_test_de.properties
@@ -1,4 +1,4 @@
-# input file for TranslationCheck
+# input file for TranslationCheck  // violation 'only.english' missing
 
 # a key that is available in all translations
 hello=Hallo

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Translation/caseOne/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Translation/caseOne/patchedline/defaultContext.patch
@@ -4,7 +4,7 @@ index 0000000..1593dac
 --- /dev/null
 +++ b/messages_test_de.properties
 @@ -0,0 +1,12 @@
-+# input file for TranslationCheck
++# input file for TranslationCheck  // violation 'only.english' missing
 +
 +# a key that is available in all translations
 +hello=Hallo

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Translation/caseOne/patchedline/messages_test_de.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Translation/caseOne/patchedline/messages_test_de.properties
@@ -1,4 +1,4 @@
-# input file for TranslationCheck
+# input file for TranslationCheck  // violation 'only.english' missing
 
 # a key that is available in all translations
 hello=Hallo

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/UniqueProperties/caseTwo/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/UniqueProperties/caseTwo/newline/defaultContext.patch
@@ -3,7 +3,7 @@ index d0c3d93..9f88fd7 100644
 --- a/test.properties
 +++ b/test.properties
 @@ -1,3 +1,4 @@
-+check=100
++check=100  // violation newline/patchedline
  A =65
  a =97
  key =107 than nothing

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/UniqueProperties/caseTwo/newline/test.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/UniqueProperties/caseTwo/newline/test.properties
@@ -1,4 +1,4 @@
-check=100
+check=100  // violation newline/patchedline
 A =65
 a =97
 key =107 than nothing

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/UniqueProperties/caseTwo/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/UniqueProperties/caseTwo/patchedline/defaultContext.patch
@@ -3,7 +3,7 @@ index d0c3d93..9f88fd7 100644
 --- a/test.properties
 +++ b/test.properties
 @@ -1,3 +1,4 @@
-+check=100
++check=100  // violation newline/patchedline
  A =65
  a =97
  key =107 than nothing

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/UniqueProperties/caseTwo/patchedline/test.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/UniqueProperties/caseTwo/patchedline/test.properties
@@ -1,4 +1,4 @@
-check=100
+check=100  // violation newline/patchedline
 A =65
 a =97
 key =107 than nothing

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/RegexpMultiline/checkID/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/RegexpMultiline/checkID/Test.java
@@ -4,17 +4,17 @@ public class Test {
     void method() {
         System.out.
                 print("Example"); // line3
-
+        // violations are on code below and line 5
+        System.out.
+                print("Example"); // line3
+        // violation is on code below
         System.out.
                 print("Example"); // line3
 
-        System.out.
-                print("Example"); // line3
 
 
 
-
-
+        // violation is on code below
         System.out.
                 print("Example");
 
@@ -24,7 +24,7 @@ public class Test {
 
 
 
-        //
+        // violation is on code below
         System.out.
                 print("Example");
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/RegexpMultiline/checkID/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/RegexpMultiline/checkID/defaultContext.patch
@@ -4,7 +4,7 @@ index d0937d7..ab5fa09 100644
 +++ b/Test.java
 @@ -16,7 +16,7 @@ public class Test {
  
- 
+         // violation is on code below
          System.out.
 -                printf("Example");
 +                print("Example");
@@ -14,7 +14,7 @@ index d0937d7..ab5fa09 100644
 @@ -25,6 +25,8 @@ public class Test {
  
  
-         ////
+         // violation is on code below
 +        System.out.
 +                print("Example");
  

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/RegexpMultiline/checkShortName/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/RegexpMultiline/checkShortName/Test.java
@@ -4,17 +4,17 @@ public class Test {
     void method() {
         System.out.
                 print("Example"); // line3
-
+        // violations are on code below and line 5
+        System.out.
+                print("Example"); // line3
+        // violation is on code below
         System.out.
                 print("Example"); // line3
 
-        System.out.
-                print("Example"); // line3
 
 
 
-
-
+        // violation is on code below
         System.out.
                 print("Example");
 
@@ -24,7 +24,7 @@ public class Test {
 
 
 
-        //
+        // violation is on code below
         System.out.
                 print("Example");
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/RegexpMultiline/checkShortName/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/RegexpMultiline/checkShortName/defaultContext.patch
@@ -4,7 +4,7 @@ index d0937d7..ab5fa09 100644
 +++ b/Test.java
 @@ -16,7 +16,7 @@ public class Test {
  
- 
+         // violation is on code below
          System.out.
 -                printf("Example");
 +                print("Example");
@@ -14,7 +14,7 @@ index d0937d7..ab5fa09 100644
 @@ -25,6 +25,8 @@ public class Test {
  
  
-         ////
+         // violation is on code below
 +        System.out.
 +                print("Example");
  

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/UniqueProperties/checkID/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/UniqueProperties/checkID/defaultContext.patch
@@ -5,7 +5,7 @@ index ef7c9f9..d0c3d93 100644
 @@ -2,6 +2,7 @@ A =65
  a =97
  key =107 than nothing
- key.sub =k is 107 and dot is 46
+ key.sub =k is 107 and dot is 46  // violation
 +key.sub =k is 107 and dot is 46
  
  
@@ -13,6 +13,6 @@ index ef7c9f9..d0c3d93 100644
 @@ -15,4 +16,4 @@ key.sub =k is 107 and dot is 46
  
  
- key.pag =value - violation
+ key.pag =value - violation  // violation
 -key.png =value - violation
 +key.pag =value - violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/UniqueProperties/checkShortName/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/neversuppressedchecks/UniqueProperties/checkShortName/defaultContext.patch
@@ -5,7 +5,7 @@ index ef7c9f9..d0c3d93 100644
 @@ -2,6 +2,7 @@ A =65
  a =97
  key =107 than nothing
- key.sub =k is 107 and dot is 46
+ key.sub =k is 107 and dot is 46  // violation
 +key.sub =k is 107 and dot is 46
  
  
@@ -13,6 +13,6 @@ index ef7c9f9..d0c3d93 100644
 @@ -15,4 +16,4 @@ key.sub =k is 107 and dot is 46
  
  
- key.pag =value - violation
+ key.pag =value - violation  // violation
 -key.png =value - violation
 +key.pag =value - violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/Test.java
@@ -2,9 +2,9 @@ package TreeWalker.AvoidNestedBlocks;
 
 public class Test {
     public void fun(boolean valid) {
-        {
+        {  // violation patchedline
             if (valid) {
-                {
+                {  // violation patchedline
                     System.out.println("ok");
                 }
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/defaultContext.patch
@@ -9,9 +9,9 @@ index bc9451d..ad14cca 100644
 -        if (valid) {
 -            {
 -                System.out.println("ok");
-+        {
++        {  // violation patchedline
 +            if (valid) {
-+                {
++                {  // violation patchedline
 +                    System.out.println("ok");
 +                }
              }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/patchedline/Test.java
@@ -2,9 +2,9 @@ package TreeWalker.AvoidNestedBlocks;
 
 public class Test {
     public void fun(boolean valid) {
-        {
+        {  // violation patchedline
             if (valid) {
-                {
+                {  // violation patchedline
                     System.out.println("ok");
                 }
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/patchedline/defaultContext.patch
@@ -9,9 +9,9 @@ index bc9451d..ad14cca 100644
 -        if (valid) {
 -            {
 -                System.out.println("ok");
-+        {
++        {  // violation patchedline
 +            if (valid) {
-+                {
++                {  // violation patchedline
 +                    System.out.println("ok");
 +                }
              }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/newline/Test.java
@@ -2,7 +2,7 @@ package TreeWalker.illegalToken;
 
 public class Test {
     public void myTest() {
-        outer: // violation
+        outer:
         for (int i = 0; i < 5; i++) {
             if (i == 1) {
                 break outer;
@@ -12,7 +12,7 @@ public class Test {
 
 
     public void Test() {
-        outer: // violation  // violation newline/patchedline
+        outer:  // violation newline/patchedline
         for (int i = 0; i < 5; i++) {
             if (i == 1) {
                 break outer;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/newline/defaultContext.patch
@@ -9,7 +9,7 @@ index 762aa6a..ff7ee3e 100644
 +
 +
 +    public void Test() {
-+        outer: // violation
++        outer:  // violation newline/patchedline
 +        for (int i = 0; i < 5; i++) {
 +            if (i == 1) {
 +                break outer;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/newline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/newline/zeroContext.patch
@@ -6,7 +6,7 @@ index 762aa6a..ff7ee3e 100644
 +
 +
 +    public void Test() {
-+        outer: // violation
++        outer:  // violation newline/patchedline
 +        for (int i = 0; i < 5; i++) {
 +            if (i == 1) {
 +                break outer;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/patchedline/Test.java
@@ -2,7 +2,7 @@ package TreeWalker.illegalToken;
 
 public class Test {
     public void myTest() {
-        outer: // violation
+        outer:
         for (int i = 0; i < 5; i++) {
             if (i == 1) {
                 break outer;
@@ -12,7 +12,7 @@ public class Test {
 
 
     public void Test() {
-        outer: // violation  // violation newline/patchedline
+        outer:  // violation newline/patchedline
         for (int i = 0; i < 5; i++) {
             if (i == 1) {
                 break outer;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/patchedline/defaultContext.patch
@@ -9,7 +9,7 @@ index 762aa6a..ff7ee3e 100644
 +
 +
 +    public void Test() {
-+        outer: // violation
++        outer:  // violation newline/patchedline
 +        for (int i = 0; i < 5; i++) {
 +            if (i == 1) {
 +                break outer;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/patchedline/zeroContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/IllegalToken/patchedline/zeroContext.patch
@@ -6,7 +6,7 @@ index 762aa6a..ff7ee3e 100644
 +
 +
 +    public void Test() {
-+        outer: // violation
++        outer:  // violation newline/patchedline
 +        for (int i = 0; i < 5; i++) {
 +            if (i == 1) {
 +                break outer;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/newline/Test.java
@@ -4,7 +4,7 @@ public class Test {
     /**
      * test
      * @param arg1 text
-     * @param arg2 text
+     * @param arg2 text  // violation
      * @return text
      */
     public int test1(Integer arg1) {
@@ -22,7 +22,7 @@ public class Test {
      * @param arg1 text
      * @return text
      */
-    public int test2(Integer arg1, Integer arg2) {
+    public int test2(Integer arg1, Integer arg2) {  // violation
         return 1;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/newline/defaultContext.patch
@@ -3,7 +3,7 @@ index 72e912a..4f2a2cf 100644
 --- a/Test.java
 +++ b/Test.java
 @@ -7,7 +7,7 @@ public class Test {
-      * @param arg2 text
+      * @param arg2 text  // violation
       * @return text
       */
 -    public int test1(Integer arg1, Integer arg2) {
@@ -18,4 +18,4 @@ index 72e912a..4f2a2cf 100644
 -     * @param arg2 text
       * @return text
       */
-     public int test2(Integer arg1, Integer arg2) {
+     public int test2(Integer arg1, Integer arg2) {  // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/Test.java
@@ -4,7 +4,7 @@ public class Test {
     /**
      * test
      * @param arg1 text
-     * @param arg2 text
+     * @param arg2 text  // violation
      * @return text
      */
     public int test1(Integer arg1) {
@@ -22,7 +22,7 @@ public class Test {
      * @param arg1 text
      * @return text
      */
-    public int test2(Integer arg1, Integer arg2) {
+    public int test2(Integer arg1, Integer arg2) {  // violation
         return 1;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/defaultContext.patch
@@ -3,7 +3,7 @@ index 72e912a..4f2a2cf 100644
 --- a/Test.java
 +++ b/Test.java
 @@ -7,7 +7,7 @@ public class Test {
-      * @param arg2 text
+      * @param arg2 text  // violation
       * @return text
       */
 -    public int test1(Integer arg1, Integer arg2) {
@@ -18,4 +18,4 @@ index 72e912a..4f2a2cf 100644
 -     * @param arg2 text
       * @return text
       */
-     public int test2(Integer arg1, Integer arg2) {
+     public int test2(Integer arg1, Integer arg2) {  // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MagicNumber/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MagicNumber/newline/Test.java
@@ -2,6 +2,6 @@ package TreeWalker.MagicNumber;
 
 public class Test {
     public void test() {
-        int a =    256;
+        int a =    256;  // violation patchedline
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MagicNumber/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MagicNumber/newline/defaultContext.patch
@@ -7,6 +7,6 @@ index b445ca2..7160c72 100644
  public class Test {
      public void test() {
 -        int a = 123;
-+        int a =    256;
++        int a =    256;  // violation patchedline
      }
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MagicNumber/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MagicNumber/patchedline/Test.java
@@ -2,6 +2,6 @@ package TreeWalker.MagicNumber;
 
 public class Test {
     public void test() {
-        int a =    256;
+        int a =    256;  // violation patchedline
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MagicNumber/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MagicNumber/patchedline/defaultContext.patch
@@ -7,6 +7,6 @@ index b445ca2..7160c72 100644
  public class Test {
      public void test() {
 -        int a = 123;
-+        int a =    256;
++        int a =    256;  // violation patchedline
      }
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodCount/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodCount/newline/Test.java
@@ -1,6 +1,6 @@
 package TreeWalker.MethodCount;
 
-public class Test {
+public class Test {  // violation context
     public void test1() {
 
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodCount/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodCount/newline/defaultContext.patch
@@ -2,7 +2,7 @@ diff --git a/Test.java b/Test.java
 index a18d11a..ca6f6b1 100644
 --- a/Test.java
 +++ b/Test.java
-@@ -4,4 +4,12 @@ public class Test {
+@@ -4,4 +4,12 @@ public class Test {  // violation context
      public void test1() {
  
      }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodCount/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodCount/patchedline/Test.java
@@ -1,7 +1,7 @@
 package TreeWalker.MethodCount;
 
 public class Test {
-    public void test1() {
+    public void test1() {  // violation context
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodCount/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodCount/patchedline/defaultContext.patch
@@ -2,7 +2,7 @@ diff --git a/Test.java b/Test.java
 index a18d11a..ca6f6b1 100644
 --- a/Test.java
 +++ b/Test.java
-@@ -4,4 +4,12 @@ public class Test {
+@@ -4,4 +4,12 @@ public class Test {  // violation context
      public void test1() {
  
      }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/newline/Test.java
@@ -1,7 +1,7 @@
 package TreeWalker.MethodLength;
 
 public class Test {
-    public void test1() {
+    public void test1() {  // violation context
         System.out.println();
         System.out.println();
         System.out.println();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/newline/defaultContext.patch
@@ -4,7 +4,7 @@ index 6ef08a3..8e76ad9 100644
 +++ b/Test.java
 @@ -3,5 +3,7 @@ package TreeWalker.MethodLength;
  public class Test {
-     public void test1() {
+     public void test1() {  // violation context
          System.out.println();
 +        System.out.println();
 +        System.out.println();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/patchedline/Test.java
@@ -1,7 +1,7 @@
 package TreeWalker.MethodLength;
 
 public class Test {
-    public void test1() {
+    public void test1() {  // violation context
         System.out.println();
         System.out.println();
         System.out.println();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodLength/patchedline/defaultContext.patch
@@ -4,7 +4,7 @@ index 6ef08a3..8e76ad9 100644
 +++ b/Test.java
 @@ -3,5 +3,7 @@ package TreeWalker.MethodLength;
  public class Test {
-     public void test1() {
+     public void test1() {  // violation context
          System.out.println();
 +        System.out.println();
 +        System.out.println();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodName/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodName/newline/Test.java
@@ -1,7 +1,7 @@
 package TreeWalker.MethodName;
 
 public class Test {
-    public void MyMethod(int a, int b) { }
+    public void MyMethod(int a, int b) { }  // violation newline/patchedline
     public void MyMethod(int a) { }
-    public void MyMethod(String a) { }
+    public void MyMethod(String a) { }  // violation newline/patchedline
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodName/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodName/newline/defaultContext.patch
@@ -6,7 +6,7 @@ index 25daab5..3eec9b8 100644
  package TreeWalker.MethodName;
  
  public class Test {
-+    public void MyMethod(int a, int b) { }
++    public void MyMethod(int a, int b) { }  // violation newline/patchedline
      public void MyMethod(int a) { }
-+    public void MyMethod(String a) { }
++    public void MyMethod(String a) { }  // violation newline/patchedline
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodName/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodName/patchedline/Test.java
@@ -1,7 +1,7 @@
 package TreeWalker.MethodName;
 
 public class Test {
-    public void MyMethod(int a, int b) { }
+    public void MyMethod(int a, int b) { }  // violation newline/patchedline
     public void MyMethod(int a) { }
-    public void MyMethod(String a) { }
+    public void MyMethod(String a) { }  // violation newline/patchedline
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodName/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MethodName/patchedline/defaultContext.patch
@@ -6,7 +6,7 @@ index 25daab5..3eec9b8 100644
  package TreeWalker.MethodName;
  
  public class Test {
-+    public void MyMethod(int a, int b) { }
++    public void MyMethod(int a, int b) { }  // violation newline/patchedline
      public void MyMethod(int a) { }
-+    public void MyMethod(String a) { }
++    public void MyMethod(String a) { }  // violation newline/patchedline
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ReturnCount/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ReturnCount/newline/Test.java
@@ -1,7 +1,7 @@
 package TreeWalker.ReturnCount;
 
 public class Test {
-    public void test(int error) {
+    public void test(int error) {  // violation context
         if (error > 100) {
             return;
         } else if (error > 50) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ReturnCount/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ReturnCount/newline/defaultContext.patch
@@ -2,7 +2,7 @@ diff --git a/Test.java b/Test.java
 index 32200a4..c49bf43 100644
 --- a/Test.java
 +++ b/Test.java
-@@ -8,6 +8,10 @@ public class Test {
+@@ -8,6 +8,10 @@ public class Test {  // violation context
              return;
          } else if (error > 40) {
              System.out.println("ok");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ReturnCount/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ReturnCount/patchedline/Test.java
@@ -1,7 +1,7 @@
 package TreeWalker.ReturnCount;
 
 public class Test {
-    public void test(int error) {
+    public void test(int error) {  // violation context
         if (error > 100) {
             return;
         } else if (error > 50) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ReturnCount/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ReturnCount/patchedline/defaultContext.patch
@@ -2,7 +2,7 @@ diff --git a/Test.java b/Test.java
 index 32200a4..c49bf43 100644
 --- a/Test.java
 +++ b/Test.java
-@@ -8,6 +8,10 @@ public class Test {
+@@ -8,6 +8,10 @@ public class Test {  // violation context
              return;
          } else if (error > 40) {
              System.out.println("ok");


### PR DESCRIPTION
minor: all Input files should have 'violation' comment/word on line where it is before filtering