### PR TITLE
Issue #132: SuppressionPatchXpathFilter: MissingOverride's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
@@ -108,6 +108,14 @@ public class SuppressionJavaPatchFilterTest extends AbstractPatchFilterEvaluatio
     }
 
     @Test
+    public void testMissingOverride() throws Exception {
+        testByConfig("MissingOverride/newline/defaultContextConfig.xml");
+        testByConfig("MissingOverride/patchedline/defaultContextConfig.xml");
+        testByConfig("MissingOverride/context/defaultContextConfig.xml");
+        testByConfig("MissingOverride/context/case2/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testMethodLength() throws Exception {
         testByConfig("MethodLength/case1/newline/defaultContextConfig.xml");
         testByConfig("MethodLength/case1/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/Test.java
@@ -1,0 +1,14 @@
+package TreeWalker.Annotation.MissingOverride;
+
+public class Test {
+
+    /** {@inheritDoc} */
+    public void test1() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    public void test2() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    private void test3() {}  // violation without filter
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/case2/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/case2/Test.java
@@ -1,0 +1,14 @@
+package TreeWalker.Annotation.MissingOverride;
+
+public class Test {
+
+    /** {@inheritDoc} */
+    public void test1() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    public void test2() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    private void test3() {}  // violation without filter
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/case2/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/case2/defaultContext.patch
@@ -1,0 +1,18 @@
+diff --git a/Test.java b/Test.java
+index 378ab7e..31e960f 100644
+--- a/Test.java
++++ b/Test.java
+@@ -3,12 +3,12 @@ package TreeWalker.Annotation.MissingOverride;
+ public class Test {
+ 
+     /** {@inheritDoc} */
+-    @Override
+     public void test1() {}  // violation without filter
+ 
+     /** {@inheritDoc} */
+     public void test2() {}  // violation without filter
+ 
++    /** {@inheritDoc} */
+     private void test3() {}  // violation without filter
+ 
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/case2/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/case2/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingOverride"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="supportContextStrategyChecks" value="MissingOverrideCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/case2/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/case2/expected.txt
@@ -1,0 +1,1 @@
+Test.java:6:5: Must include @java.lang.Override annotation when {@inheritDoc} Javadoc tag exists.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/defaultContext.patch
@@ -1,0 +1,18 @@
+diff --git a/Test.java b/Test.java
+index 378ab7e..31e960f 100644
+--- a/Test.java
++++ b/Test.java
+@@ -3,12 +3,12 @@ package TreeWalker.Annotation.MissingOverride;
+ public class Test {
+ 
+     /** {@inheritDoc} */
+-    @Override
+     public void test1() {}  // violation without filter
+ 
+     /** {@inheritDoc} */
+     public void test2() {}  // violation without filter
+ 
++    /** {@inheritDoc} */
+     private void test3() {}  // violation without filter
+ 
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingOverride"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="MissingOverrideCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/context/expected.txt
@@ -1,0 +1,3 @@
+Test.java:12:5: The Javadoc {@inheritDoc} tag is not valid at this location.
+Test.java:6:5: Must include @java.lang.Override annotation when {@inheritDoc} Javadoc tag exists.
+Test.java:9:5: Must include @java.lang.Override annotation when {@inheritDoc} Javadoc tag exists.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/newline/Test.java
@@ -1,0 +1,17 @@
+package TreeWalker.Annotation.MissingOverride;
+
+public class Test {
+
+    /** {@inheritDoc} */
+    public void test1() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    public void test2() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    private void test3() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    private void test4() {}  // violation without filter
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/newline/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 31e960f..165f205 100644
+--- a/Test.java
++++ b/Test.java
+@@ -11,4 +11,7 @@ public class Test {
+     /** {@inheritDoc} */
+     private void test3() {}  // violation without filter
+ 
++    /** {@inheritDoc} */
++    private void test4() {}  // violation without filter
++
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingOverride"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:15:5: The Javadoc {@inheritDoc} tag is not valid at this location.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/patchedline/Test.java
@@ -1,0 +1,17 @@
+package TreeWalker.Annotation.MissingOverride;
+
+public class Test {
+
+    /** {@inheritDoc} */
+    public void test1() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    public void test2() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    private void test3() {}  // violation without filter
+
+    /** {@inheritDoc} */
+    private void test4() {}  // violation without filter
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/patchedline/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 31e960f..165f205 100644
+--- a/Test.java
++++ b/Test.java
+@@ -11,4 +11,7 @@ public class Test {
+     /** {@inheritDoc} */
+     private void test3() {}  // violation without filter
+ 
++    /** {@inheritDoc} */
++    private void test4() {}  // violation without filter
++
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingOverride"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingOverride/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:15:5: The Javadoc {@inheritDoc} tag is not valid at this location.


### PR DESCRIPTION
Issue #132: SuppressionPatchXpathFilter: MissingOverride's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-666272689

There are two problems when I solve MissingOverride's context strategy.

First Problem: There is only a deleted line, but this deleted line will cause a violation in MissingOverride: Test.java:6:5: Must include @java.lang.Override annotation when {@inheritdoc} Javadoc tag exists.
but now in current suppressionPatchXpathFilter version, we only consider the added/changed line, not deleted line. The reason that deleted line does not be considered is that deleted line does not belong to current java file that do checkstyle, so it is difficult to deal with it. now deleted line information has been considered in #162.

Second Problem: When I run ` java $RUN_LOCALE -jar checkstyle-8.34-SNAPSHOT-all.jar -T Test.java`, I get :

```
|--METHOD_DEF -> METHOD_DEF [11:4]
    |   |--MODIFIERS -> MODIFIERS [11:4]
    |   |   |--BLOCK_COMMENT_BEGIN -> /* [10:4]
    |   |   |   |--COMMENT_CONTENT -> * {@inheritDoc}  [10:6]
    |   |   |   `--BLOCK_COMMENT_END -> */ [10:21]
    |   |   `--LITERAL_PUBLIC -> public [11:4]
    |   |--TYPE -> TYPE [11:11]
    |   |   `--LITERAL_VOID -> void [11:11]
    |   |--IDENT -> test2 [11:16]
    |   |--LPAREN -> ( [11:21]
    |   |--PARAMETERS -> PARAMETERS [11:22]
    |   |--RPAREN -> ) [11:22]
    |   `--SLIST -> { [11:24]
    |       |--SINGLE_LINE_COMMENT -> // [11:27]
    |       |   `--COMMENT_CONTENT ->  violation context\n [11:29]
    |       `--RCURLY -> } [13:4]
```
So, MODIFIERS is child node of METHOD_DEF, so I thought that this context strategy can be solved by previous solution, but in fact that in TreeWalkerAuditEvent event, the AST does not include comments, modifiers, so how do we solve this situation?