### PR TITLE
Issue #136: SuppressionPatchXpathFilter: AvoidNestedBlocks's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -251,10 +251,9 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
 
     @Test
     public void testAvoidNestedBlocks() throws Exception {
-        testByConfig(
-                "AvoidNestedBlocks/newline/defaultContextConfig.xml");
-        testByConfig(
-                "AvoidNestedBlocks/patchedline/defaultContextConfig.xml");
+        testByConfig("AvoidNestedBlocks/newline/defaultContextConfig.xml");
+        testByConfig("AvoidNestedBlocks/patchedline/defaultContextConfig.xml");
+        testByConfig("AvoidNestedBlocks/context/defaultContextConfig.xml");
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/context/Test.java
@@ -1,0 +1,46 @@
+package TreeWalker.AvoidNestedBlocks;
+
+public class Test {
+    public void test() {
+        int x = 0;
+
+        {  // violation without filter
+            int z = 1;
+            int y = z;
+            int h = z;
+            h = 0;
+        }
+
+        {  // violation without filter
+            x = 2;
+        }
+
+//        if (x == 1)
+        {  // violation without filter
+            x = 2;
+        }
+
+        switch (x) {
+            case 0:
+                // OK
+                x = 3;
+                break;
+            case 1:
+                {  // violation without filter
+                    x = 1;
+                }
+                break;
+            case 2:
+                {  // violation without filter
+                    x = 1;
+                    break;
+                }
+            case 3: // test fallthrough
+            default:
+                System.identityHashCode("Hello");
+                {  // violation without filter
+                    x = 2;
+                }
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/context/defaultContext.patch
@@ -1,0 +1,37 @@
+diff --git a/Test.java b/Test.java
+index cf7b319..81ce376 100644
+--- a/Test.java
++++ b/Test.java
+@@ -8,14 +8,14 @@ public class Test {
+             int z = 1;
+             int y = z;
+             int h = z;
++            h = 0;
+         }
+ 
+-        if (x == 1)
+         {  // violation without filter
+             x = 2;
+         }
+ 
+-        if (x == 1)
++//        if (x == 1)
+         {  // violation without filter
+             x = 2;
+         }
+@@ -29,6 +29,7 @@ public class Test {
+                 {  // violation without filter
+                     x = 1;
+                 }
++                break;
+             case 2:
+                 {
+                     x = 1;
+@@ -36,6 +37,7 @@ public class Test {
+                 }
+             case 3: // test fallthrough
+             default:
++                System.identityHashCode("Hello");
+                 {  // violation without filter
+                     x = 2;
+                 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="AvoidNestedBlocks"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="AvoidNestedBlocksCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/context/expected.txt
@@ -1,0 +1,6 @@
+Test.java:14:9: Avoid nested blocks.
+Test.java:19:9: Avoid nested blocks.
+Test.java:29:17: Avoid nested blocks.
+Test.java:34:17: Avoid nested blocks.
+Test.java:41:17: Avoid nested blocks.
+Test.java:7:9: Avoid nested blocks.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/Test.java
@@ -1,13 +1,9 @@
-package TreeWalker.AvoidNestedBlocks;
+package TreeWalker.blocks.AvoidNestedBlocks;
 
 public class Test {
     public void fun(boolean valid) {
         {  // violation without filter
-            if (valid) {
-                {  // violation without filter
-                    System.out.println("ok");
-                }
-            }
+            System.out.println(valid);
         }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/defaultContext.patch
@@ -1,19 +1,15 @@
 diff --git a/Test.java b/Test.java
-index bc9451d..ad14cca 100644
---- a/Test.java
+new file mode 100644
+index 0000000..024e7da
+--- /dev/null
 +++ b/Test.java
-@@ -2,9 +2,11 @@ package TreeWalker.AvoidNestedBlocks;
- 
- public class Test {
-     public void fun(boolean valid) {
--        if (valid) {
--            {
--                System.out.println("ok");
+@@ -0,0 +1,9 @@
++package TreeWalker.blocks.AvoidNestedBlocks;
++
++public class Test {
++    public void fun(boolean valid) {
 +        {  // violation without filter
-+            if (valid) {
-+                {  // violation without filter
-+                    System.out.println("ok");
-+                }
-             }
-         }
-     }
++            System.out.println(valid);
++        }
++    }
++}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/AvoidNestedBlocks/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:5:9: Avoid nested blocks.


### PR DESCRIPTION
Issue #136: SuppressionPatchXpathFilter: AvoidNestedBlocks's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665565892
There is one problem that previous line removed/added/changed cause a violation, how do we solve this problem:

```
-        if (x == 1)
         {  // violation context
             x = 2;
         }

```
removed line `if (x == 1)` will caused a violation, but ` if (x == 1)` is not child node of `{ `, so this violation will be suppressed, but should not.

second one is that:

```
-        if (x == 1)
+//        if (x == 1)
         {  // violation context
             x = 2;
         }
```
```
 |--SINGLE_LINE_COMMENT -> // [18:0]
    |       |   `--COMMENT_CONTENT ->         if (x == 1)\n [18:2]
    |       |--SLIST -> { [19:8]
    |       |   |--EXPR -> EXPR [20:14]
    |       |   |   `--ASSIGN -> = [20:14]
    |       |   |       |--SINGLE_LINE_COMMENT -> // [19:11]
    |       |   |       |   `--COMMENT_CONTENT ->  violation context\n [19:13]
    |       |   |       |--IDENT -> x [20:12]
    |       |   |       `--NUM_INT -> 2 [20:16]
    |       |   |--SEMI -> ; [20:17]
    |       |   `--RCURLY -> } [21:8]

```
`//        if (x == 1)` will caused a violation, but `//        if (x == 1)` is also not child node of `{ `, so this violation will be suppressed, but should not.

```
              default:
+                System.identityHashCode("Hello");
                 {  // violation context
                     x = 2;
                 }

```
same problem, previous line added not child node of `{`