### PR TITLE
Issue #142: SuppressionPatchXpathFilter: RightCurly's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -409,6 +409,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testRightCurly() throws Exception {
+        testByConfig("RightCurly/newline/defaultContextConfig.xml");
+        testByConfig("RightCurly/patchedline/defaultContextConfig.xml");
+        testByConfig("RightCurly/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testEmptyStatement() throws Exception {
         testByConfig("EmptyStatement/newline/defaultContextConfig.xml");
         testByConfig("EmptyStatement/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/context/Test.java
@@ -1,0 +1,32 @@
+package TreeWalker.blocks.RightCurly;
+
+public class Test {
+    public void test() {
+        int x = 0;
+        while (true) {
+            try {
+                if (x > 0)
+                {
+                    break;
+                }  // violation without filter
+                else if (x < 0)
+                {
+                    ;
+                }  // violation without filter
+                else
+                {
+                    break;
+                }
+
+            }  // violation without filter
+            catch (Exception e)
+            {
+                break;  //changed
+            }  // violation without filter
+            finally
+            {
+                break;
+            }
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/context/defaultContext.patch
@@ -1,0 +1,21 @@
+diff --git a/Test.java b/Test.java
+index c07979d..35e1c6f 100644
+--- a/Test.java
++++ b/Test.java
+@@ -13,11 +13,15 @@ public class Test {
+                 {
+                     ;
+                 }  // violation without filter
++                else
++                {
++                    break;
++                }
+ 
+             }  // violation without filter
+             catch (Exception e)
+             {
+-                break;
++                break;  //changed
+             }  // violation without filter
+             finally
+             {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="RightCurly"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="RightCurlyCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/context/expected.txt
@@ -1,0 +1,4 @@
+Test.java:11:17: '}' at column 17 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally).
+Test.java:15:17: '}' at column 17 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally).
+Test.java:21:13: '}' at column 13 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally).
+Test.java:25:13: '}' at column 13 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally).

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/newline/Test.java
@@ -1,0 +1,14 @@
+package TreeWalker.blocks.RightCurly;
+
+public class Test2 {
+    public void test(int x) {
+        if (x > 0)
+        {
+            System.out.println(x);
+        }  // violation without filter
+        else if (x < 0)
+        {
+            ;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/newline/defaultContext.patch
@@ -1,0 +1,20 @@
+diff --git a/Test.java b/Test.java
+new file mode 100644
+index 0000000..b2ada7e
+--- /dev/null
++++ b/Test.java
+@@ -0,0 +1,14 @@
++package TreeWalker.blocks.RightCurly;
++
++public class Test {
++    public void test(int x) {
++        if (x > 0)
++        {
++            System.out.println(x);
++        }  // violation without filter
++        else if (x < 0)
++        {
++            ;
++        }
++    }
++}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="RightCurly"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:8:9: '}' at column 9 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally).

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/patchedline/Test.java
@@ -1,0 +1,14 @@
+package TreeWalker.blocks.RightCurly;
+
+public class Test {
+    public void test(int x) {
+        if (x > 0)
+        {
+            System.out.println(x);
+        }  // violation without filter
+        else if (x < 0)
+        {
+            ;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/patchedline/defaultContext.patch
@@ -1,0 +1,20 @@
+diff --git a/Test.java b/Test.java
+new file mode 100644
+index 0000000..b2ada7e
+--- /dev/null
++++ b/Test.java
+@@ -0,0 +1,14 @@
++package TreeWalker.blocks.RightCurly;
++
++public class Test {
++    public void test(int x) {
++        if (x > 0)
++        {
++            System.out.println(x);
++        }  // violation without filter
++        else if (x < 0)
++        {
++            ;
++        }
++    }
++}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="RightCurly"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/RightCurly/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:8:9: '}' at column 9 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally).


### PR DESCRIPTION
Issue #142: SuppressionPatchXpathFilter: RightCurly's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665565892


should have violation, but not now, because
```java
else
{
```
is not `}` 's child node.

---

```
             }  // violation context
             catch (Exception e)
             {
-                break;
+                break;  //changed
             }
             finally
             {
```
```
catch (Exception e)
             {
``` 
is not `}`'s child node