### PR TITLE
Issue #146: SuppressionPatchXpathFilter: ArrayTrailingComma's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -349,6 +349,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testArrayTrailingComma() throws Exception {
+        testByConfig("ArrayTrailingComma/newline/defaultContextConfig.xml");
+        testByConfig("ArrayTrailingComma/patchedline/defaultContextConfig.xml");
+        testByConfig("ArrayTrailingComma/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testExecutableStatementCount() throws Exception {
         testByConfig(
                 "sizes/ExecutableStatementCount/newline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/context/Test.java
@@ -1,0 +1,15 @@
+package TreeWalker.coding.ArrayTrailingComma;
+
+public class Test {
+    public void test() {
+        int[] a2 = new int[]{
+                1,
+                2  // violation without filter
+                };
+
+        int[] a3 = new int[]{
+                1,
+                2  // violation without filter
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/context/defaultContext.patch
@@ -1,0 +1,18 @@
+diff --git a/Test.java b/Test.java
+index 5634b6b..3a74722 100644
+--- a/Test.java
++++ b/Test.java
+@@ -5,12 +5,11 @@ public class Test {
+         int[] a2 = new int[]{
+                 1,
+                 2  // violation without filter
+-                ,};
++                };
+ 
+         int[] a3 = new int[]{
+                 1,
+                 2  // violation without filter
+-                ,
+         };
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/context/defaultContextConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="ArrayTrailingComma">
+            <property name="alwaysDemandTrailingComma" value="true"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="ArrayTrailingCommaCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/context/expected.txt
@@ -1,0 +1,2 @@
+Test.java:12:17: Array should contain trailing comma.
+Test.java:7:17: Array should contain trailing comma.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/newline/Test.java
@@ -1,0 +1,22 @@
+package TreeWalker.coding.ArrayTrailingComma;
+
+public class Test {
+    public void test() {
+        int[] a2 = new int[]{
+                1,
+                2  // violation without filter
+                };
+
+        int[] a3 = new int[]{
+                1,
+                2  // violation without filter
+        };
+    }
+
+    public void test1() {
+        int[] a4 = new int[]{
+                3,
+                4  // violation without filter
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/newline/defaultContext.patch
@@ -1,0 +1,16 @@
+diff --git a/Test.java b/Test.java
+index 3a74722..91799e1 100644
+--- a/Test.java
++++ b/Test.java
+@@ -12,4 +12,11 @@ public class Test {
+                 2  // violation without filter
+         };
+     }
++
++    public void test1() {
++        int[] a4 = new int[]{
++                3,
++                4  // violation without filter
++        };
++    }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/newline/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="ArrayTrailingComma">
+            <property name="alwaysDemandTrailingComma" value="true"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:19:17: Array should contain trailing comma.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/patchedline/Test.java
@@ -1,0 +1,22 @@
+package TreeWalker.coding.ArrayTrailingComma;
+
+public class Test {
+    public void test() {
+        int[] a2 = new int[]{
+                1,
+                2  // violation without filter
+                };
+
+        int[] a3 = new int[]{
+                1,
+                2  // violation without filter
+        };
+    }
+
+    public void test1() {
+        int[] a4 = new int[]{
+                3,
+                4  // violation without filter
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/patchedline/defaultContext.patch
@@ -1,0 +1,16 @@
+diff --git a/Test.java b/Test.java
+index 3a74722..91799e1 100644
+--- a/Test.java
++++ b/Test.java
+@@ -12,4 +12,11 @@ public class Test {
+                 2  // violation without filter
+         };
+     }
++
++    public void test1() {
++        int[] a4 = new int[]{
++                3,
++                4  // violation without filter
++        };
++    }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/patchedline/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="ArrayTrailingComma">
+            <property name="alwaysDemandTrailingComma" value="true"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/ArrayTrailingComma/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:19:17: Array should contain trailing comma.


### PR DESCRIPTION
Issue #146: SuppressionPatchXpathFilter: ArrayTrailingComma's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665565892

```
                 2  // context violation
-                ,};
+                };
 
         int[] a3 = new int[]{
                 1,
                 2  // context violation
-                ,
         };

```
Problem: `};` and ` ,` are not child node of 2