### PR TITLE
Issue #150: SuppressionPatchXpathFilter: CovariantEquals's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -282,6 +282,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testCovariantEquals() throws Exception {
+        testByConfig("CovariantEquals/newline/defaultContextConfig.xml");
+        testByConfig("CovariantEquals/patchedline/defaultContextConfig.xml");
+        testByConfig("CovariantEquals/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testAnonInnerLength() throws Exception {
         testByConfig(
                 "sizes/AnonInnerLength/newline/defaultContextConfig.xml");
@@ -482,13 +489,6 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
         testByConfig("SimplifyBooleanReturn/newline/defaultContextConfig.xml");
         testByConfig("SimplifyBooleanReturn/patchedline/defaultContextConfig.xml");
         testByConfig("SimplifyBooleanReturn/context/defaultContextConfig.xml");
-    }
-
-    @Test
-    public void testCovariantEquals() throws Exception {
-        testByConfig("CovariantEquals/newline/defaultContextConfig.xml");
-        testByConfig("CovariantEquals/patchedline/defaultContextConfig.xml");
-        testByConfig("CovariantEquals/context/defaultContextConfig.xml");
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/context/defaultContextConfig.xml
@@ -9,7 +9,7 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="context" />
-            <property name="supportContextStrategyChecks" value="CovariantEqualsCheck" />
+            <property name="neverSuppressedChecks" value="CovariantEqualsCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/context/expected.txt
@@ -1,0 +1,2 @@
+Test.java:11:20: covariant equals without overriding equals(java.lang.Object).
+Test.java:4:20: covariant equals without overriding equals(java.lang.Object).

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/newline/Test.java
@@ -16,3 +16,14 @@ class Test2 {
 //        return false;
 //    }
 }
+
+
+
+
+
+
+class Test3 {
+    public boolean equals(TreeWalker.coding.CovariantEquals.Test i) {  // violation without filter
+        return false;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/newline/defaultContext.patch
@@ -1,5 +1,5 @@
 diff --git a/Test.java b/Test.java
-index cfa1cc7..6011bfc 100644
+index 630cdd9..b0ed5da 100644
 --- a/Test.java
 +++ b/Test.java
 @@ -5,9 +5,6 @@ public class Test {
@@ -12,7 +12,7 @@ index cfa1cc7..6011bfc 100644
  }
  
  class Test2 {
-@@ -15,7 +12,7 @@ class Test2 {
+@@ -15,12 +12,18 @@ class Test2 {
          return false;
      }
  
@@ -23,3 +23,14 @@ index cfa1cc7..6011bfc 100644
 +//        return false;
 +//    }
  }
+ 
+ 
+ 
+ 
+ 
++
++class Test3 {
++    public boolean equals(Test i) {  // violation without filter
++        return false;
++    }
++}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:26:20: covariant equals without overriding equals(java.lang.Object).

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/patchedline/Test.java
@@ -16,3 +16,9 @@ class Test2 {
 //        return false;
 //    }
 }
+
+class Test3 {
+    public boolean equals(TreeWalker.coding.CovariantEquals.Test i) {  // violation without filter
+        return false;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/patchedline/defaultContext.patch
@@ -1,25 +1,14 @@
 diff --git a/Test.java b/Test.java
-index cfa1cc7..6011bfc 100644
+index 6011bfc..9955098 100644
 --- a/Test.java
 +++ b/Test.java
-@@ -5,9 +5,6 @@ public class Test {
-         return false;
-     }
- 
--    public boolean equals(Object i) {
--        return false;
--    }
+@@ -16,3 +16,9 @@ class Test2 {
+ //        return false;
+ //    }
  }
- 
- class Test2 {
-@@ -15,7 +12,7 @@ class Test2 {
-         return false;
-     }
- 
--    public boolean equals(Object i) {
--        return false;
--    }
-+//    public boolean equals(Object i) {
-+//        return false;
-+//    }
- }
++
++class Test3 {
++    public boolean equals(Test i) {  // violation without filter
++        return false;
++    }
++}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/CovariantEquals/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:21:20: covariant equals without overriding equals(java.lang.Object).


### PR DESCRIPTION
Issue #150: SuppressionPatchXpathFilter: CovariantEquals's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665565892

delete `equals(Object i)`, should have violation, but not now.

annotate `equals(Object i)`, should have violation, but not now.