### PR TITLE
Issue #157: SuppressionPatchXpathFilter: FallThrough's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -243,6 +243,17 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testFallThrough() throws Exception {
+        testByConfig("FallThrough/case1/newline/defaultContextConfig.xml");
+        testByConfig("FallThrough/case1/patchedline/defaultContextConfig.xml");
+        testByConfig("FallThrough/case1/context/defaultContextConfig.xml");
+
+        testByConfig("FallThrough/case2/newline/defaultContextConfig.xml");
+        testByConfig("FallThrough/case2/patchedline/defaultContextConfig.xml");
+        testByConfig("FallThrough/case2/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testEmptyBlock() throws Exception {
         testByConfig("EmptyBlock/newline/defaultContextConfig.xml");
         testByConfig("EmptyBlock/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/context/Test.java
@@ -1,0 +1,24 @@
+package TreeWalker.coding.FallThrough;
+
+public class Test {
+    public void test(int i) {
+        switch (i) {
+            case 0:
+                i++;
+                break;
+            case 1:
+                i++;
+            case 2:  // violation without filter
+            case 3:
+            case 4: {
+                i++;
+            }
+            case 5:  // violation without filter
+                i++;
+            case 6:  // violation without filter
+                i++;
+            case 7:  // violation without filter
+                i++;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/context/defaultContext.patch
@@ -1,0 +1,23 @@
+diff --git a/Test.java b/Test.java
+index 397f121..cf434a7 100644
+--- a/Test.java
++++ b/Test.java
+@@ -5,9 +5,9 @@ public class Test {
+         switch (i) {
+             case 0:
+                 i++;
++                break;
+             case 1:
+                 i++;
+-                // falls through
+             case 2:  // violation without filter
+             case 3:
+             case 4: {
+@@ -19,7 +19,6 @@ public class Test {
+                 i++;
+             case 7:  // violation without filter
+                 i++;
+-                break;
+         }
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FallThrough"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="FallThroughCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/context/expected.txt
@@ -1,0 +1,4 @@
+Test.java:11:13: Fall through from previous branch of the switch statement.
+Test.java:16:13: Fall through from previous branch of the switch statement.
+Test.java:18:13: Fall through from previous branch of the switch statement.
+Test.java:20:13: Fall through from previous branch of the switch statement.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/newline/Test.java
@@ -1,0 +1,26 @@
+package TreeWalker.coding.FallThrough;
+
+public class Test {
+    public void test(int i) {
+        switch (i) {
+            case 0:
+                i++;
+                break;
+            case 1:
+                i++;
+            case 2:  // violation without filter
+            case 3:
+            case 4: {
+                i++;
+            }
+            case 5:  // violation without filter
+                i++;
+            case 6:  // violation without filter
+                i++;
+            case 7:  // violation without filter
+                i++;
+            case 8:  // violation without filter
+                i++;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/newline/defaultContext.patch
@@ -1,0 +1,13 @@
+diff --git a/Test.java b/Test.java
+index cf434a7..f214f5d 100644
+--- a/Test.java
++++ b/Test.java
+@@ -19,6 +19,8 @@ public class Test {
+                 i++;
+             case 7:  // violation without filter
+                 i++;
++            case 8:  // violation without filter
++                i++;
+         }
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FallThrough"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:22:13: Fall through from previous branch of the switch statement.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/patchedline/Test.java
@@ -1,0 +1,26 @@
+package TreeWalker.coding.FallThrough;
+
+public class Test {
+    public void test(int i) {
+        switch (i) {
+            case 0:
+                i++;
+                break;
+            case 1:
+                i++;
+            case 2:  // violation without filter
+            case 3:
+            case 4: {
+                i++;
+            }
+            case 5:  // violation without filter
+                i++;
+            case 6:  // violation without filter
+                i++;
+            case 7:  // violation without filter
+                i++;
+            case 8:  // violation without filter
+                i++;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/patchedline/defaultContext.patch
@@ -1,0 +1,13 @@
+diff --git a/Test.java b/Test.java
+index cf434a7..f214f5d 100644
+--- a/Test.java
++++ b/Test.java
+@@ -19,6 +19,8 @@ public class Test {
+                 i++;
+             case 7:  // violation without filter
+                 i++;
++            case 8:  // violation without filter
++                i++;
+         }
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FallThrough"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case1/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:22:13: Fall through from previous branch of the switch statement.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/context/Test.java
@@ -1,0 +1,28 @@
+package TreeWalker.coding.FallThrough;
+
+public class Test {
+    public void test(int i) {
+        switch (i) {
+            case 6:
+                i++;
+            case 7:  // violation without filter
+                i++;
+        }
+
+        switch (i) {
+            case 8:
+                i++;
+            case 9:  // violation without filter
+                i++;
+                System.out.println();
+        }
+
+        switch (i) {
+            case 10:
+                i++;
+            case 11:  // violation without filter
+                i++;
+                System.out.println();
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/context/defaultContext.patch
@@ -1,0 +1,29 @@
+diff --git a/Test.java b/Test.java
+index cac02d9..351265a 100644
+--- a/Test.java
++++ b/Test.java
+@@ -7,7 +7,6 @@ public class Test {
+                 i++;
+             case 7:  // violation without filter
+                 i++;
+-                break;
+         }
+ 
+         switch (i) {
+@@ -15,7 +14,7 @@ public class Test {
+                 i++;
+             case 9:  // violation without filter
+                 i++;
+-                break;
++                System.out.println();
+         }
+ 
+         switch (i) {
+@@ -23,6 +22,7 @@ public class Test {
+                 i++;
+             case 11:  // violation without filter
+                 i++;
++                System.out.println();
+         }
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FallThrough"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="FallThroughCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/context/expected.txt
@@ -1,0 +1,3 @@
+Test.java:15:13: Fall through from previous branch of the switch statement.
+Test.java:23:13: Fall through from previous branch of the switch statement.
+Test.java:8:13: Fall through from previous branch of the switch statement.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/newline/Test.java
@@ -1,0 +1,28 @@
+package TreeWalker.coding.FallThrough;
+
+public class Test {
+    public void test(int i) {
+        switch (i) {
+            case 6:
+                i++;
+            case 7:  // violation without filter
+                i++;
+        }
+
+        switch (i) {
+            case 8:
+                i++;
+            case 9:  // violation without filter
+                i++;
+                System.out.println();
+        }
+
+        switch (i) {
+            case 10:
+                i++;
+            case 11:  // violation without filter
+                i++;
+                System.out.println();
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/newline/defaultContext.patch
@@ -1,0 +1,29 @@
+diff --git a/Test.java b/Test.java
+index cac02d9..351265a 100644
+--- a/Test.java
++++ b/Test.java
+@@ -7,7 +7,6 @@ public class Test {
+                 i++;
+             case 7:  // violation without filter
+                 i++;
+-                break;
+         }
+ 
+         switch (i) {
+@@ -15,7 +14,7 @@ public class Test {
+                 i++;
+             case 9:  // violation without filter
+                 i++;
+-                break;
++                System.out.println();
+         }
+ 
+         switch (i) {
+@@ -23,6 +22,7 @@ public class Test {
+                 i++;
+             case 11:  // violation without filter
+                 i++;
++                System.out.println();
+         }
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FallThrough"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/patchedline/Test.java
@@ -1,0 +1,28 @@
+package TreeWalker.coding.FallThrough;
+
+public class Test {
+    public void test(int i) {
+        switch (i) {
+            case 6:
+                i++;
+            case 7:  // violation without filter
+                i++;
+        }
+
+        switch (i) {
+            case 8:
+                i++;
+            case 9:  // violation without filter
+                i++;
+                System.out.println();
+        }
+
+        switch (i) {
+            case 10:
+                i++;
+            case 11:  // violation without filter
+                i++;
+                System.out.println();
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/patchedline/defaultContext.patch
@@ -1,0 +1,29 @@
+diff --git a/Test.java b/Test.java
+index cac02d9..351265a 100644
+--- a/Test.java
++++ b/Test.java
+@@ -7,7 +7,6 @@ public class Test {
+                 i++;
+             case 7:  // violation without filter
+                 i++;
+-                break;
+         }
+ 
+         switch (i) {
+@@ -15,7 +14,7 @@ public class Test {
+                 i++;
+             case 9:  // violation without filter
+                 i++;
+-                break;
++                System.out.println();
+         }
+ 
+         switch (i) {
+@@ -23,6 +22,7 @@ public class Test {
+                 i++;
+             case 11:  // violation without filter
+                 i++;
++                System.out.println();
+         }
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FallThrough/case2/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FallThrough"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>


### PR DESCRIPTION
Issue #157: SuppressionPatchXpathFilter: FallThrough's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665565892

this change is for a special case that if the deletion line is the last line, then although we consider deletion line information in #162, it still can not be matched, because the last line is out of range of current java version. for example:

```java
case 7:  // violation context line 20
     i++; // line 21
    break; // line 22
```
if we delete line 22, and we consider deletion line information 22, it still not ok, because now `getChildAstLineNo` just get 20-21, no 22

another problem:

```
             case 1:
                 i++;
-                // falls through
             case 2:  // violation context

```
deleted line ` // falls through` is not `case 2`'s child node.