### PR TITLE
Issue #163: SuppressionPatchXpathFilter: FinalLocalVariable's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -377,6 +377,17 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testFinalLocalVariable() throws Exception {
+        testByConfig("FinalLocalVariable/case1/newline/defaultContextConfig.xml");
+        testByConfig("FinalLocalVariable/case1/patchedline/defaultContextConfig.xml");
+        testByConfig("FinalLocalVariable/case1/context/defaultContextConfig.xml");
+
+        testByConfig("FinalLocalVariable/case2/newline/defaultContextConfig.xml");
+        testByConfig("FinalLocalVariable/case2/patchedline/defaultContextConfig.xml");
+        testByConfig("FinalLocalVariable/case2/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testBooleanExpressionComplexity() throws Exception {
         testByConfig("BooleanExpressionComplexity/newline/defaultContextConfig.xml");
         testByConfig("BooleanExpressionComplexity/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/context/Test.java
@@ -1,0 +1,14 @@
+package TreeWalker.coding.FinalLocalVariable;
+
+public class Test {
+    static int foo(int x, int y) {  // violation without filter
+        return x+y;
+    }
+    public static void main (String []args) {  // violation without filter
+        for (String i : args) {
+            System.out.println(i);
+            System.out.println(i);
+        }
+        int result=foo(1,2);  // violation without filter
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/context/defaultContext.patch
@@ -1,0 +1,18 @@
+diff --git a/Test.java b/Test.java
+index 2a731db..eb996ad 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,12 +2,12 @@ package TreeWalker.coding.FinalLocalVariable;
+ 
+ public class Test {
+     static int foo(int x, int y) {  // violation without filter
+-        x = 1;
+         return x+y;
+     }
+     public static void main (String []args) {  // violation without filter
+         for (String i : args) {
+             System.out.println(i);
++            System.out.println(i);
+         }
+         int result=foo(1,2);  // violation without filter
+     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/context/defaultContextConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FinalLocalVariable">
+            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="FinalLocalVariableCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/context/expected.txt
@@ -1,0 +1,4 @@
+Test.java:4:24: Variable 'x' should be declared final.
+Test.java:4:31: Variable 'y' should be declared final.
+Test.java:7:39: Variable 'args' should be declared final.
+Test.java:12:13: Variable 'result' should be declared final.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/newline/Test.java
@@ -1,0 +1,18 @@
+package TreeWalker.coding.FinalLocalVariable;
+
+public class Test {
+    static int foo(int x, int y) {  // violation without filter
+        return x+y;
+    }
+    public static void main (String [] args) {  // violation without filter
+        for (String i : args) {
+            System.out.println(i);
+            System.out.println(i);
+        }
+        int result=foo(1,2);  // violation without filter
+    }
+
+    static int foo1(int x, int y) {  // violation without filter
+        return x+y;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/newline/defaultContext.patch
@@ -1,0 +1,21 @@
+diff --git a/Test.java b/Test.java
+index 93c2b00..64be41d 100644
+--- a/Test.java
++++ b/Test.java
+@@ -4,11 +4,15 @@ public class Test {
+     static int foo(int x, int y) {  // violation without filter
+         return x+y;
+     }
+-    public static void main (String []args) {
++    public static void main (String [] args) {  // violation without filter
+         for (String i : args) {
+             System.out.println(i);
+             System.out.println(i);
+         }
+         int result=foo(1,2);
+     }
++
++    static int foo1(int x, int y) {  // violation without filter
++        return x+y;
++    }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/newline/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FinalLocalVariable">
+            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/newline/expected.txt
@@ -1,0 +1,2 @@
+Test.java:15:25: Variable 'x' should be declared final.
+Test.java:15:32: Variable 'y' should be declared final.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/patchedline/Test.java
@@ -1,0 +1,18 @@
+package TreeWalker.coding.FinalLocalVariable;
+
+public class Test {
+    static int foo(int x, int y) {  // violation without filter
+        return x+y;
+    }
+    public static void main (String [] args) {  // violation without filter
+        for (String i : args) {
+            System.out.println(i);
+            System.out.println(i);
+        }
+        int result=foo(1,2);  // violation without filter
+    }
+
+    static int foo1(int x, int y) {  // violation without filter
+        return x+y;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/patchedline/defaultContext.patch
@@ -1,0 +1,21 @@
+diff --git a/Test.java b/Test.java
+index 93c2b00..64be41d 100644
+--- a/Test.java
++++ b/Test.java
+@@ -4,11 +4,15 @@ public class Test {
+     static int foo(int x, int y) {  // violation without filter
+         return x+y;
+     }
+-    public static void main (String []args) {
++    public static void main (String [] args) {  // violation without filter
+         for (String i : args) {
+             System.out.println(i);
+             System.out.println(i);
+         }
+         int result=foo(1,2);
+     }
++
++    static int foo1(int x, int y) {  // violation without filter
++        return x+y;
++    }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/patchedline/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FinalLocalVariable">
+            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case1/patchedline/expected.txt
@@ -1,0 +1,3 @@
+Test.java:15:25: Variable 'x' should be declared final.
+Test.java:15:32: Variable 'y' should be declared final.
+Test.java:7:40: Variable 'args' should be declared final.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/context/Test.java
@@ -1,0 +1,17 @@
+package TreeWalker.coding.FinalLocalVariable;
+
+public class Test {
+    static int foo(int x, int y) {  // violation without filter
+        x = 1;
+        return x+y;
+    }
+    public static void main (String []args) {  // violation without filter
+        for (String i : args) {
+            System.out.println(i);
+        }
+        int result=foo(1,2);  // violation without filter
+
+        int myconst  // violation without filter
+                = foo(1, 2);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/context/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 618536b..7d45dea 100644
+--- a/Test.java
++++ b/Test.java
+@@ -12,6 +12,6 @@ public class Test {
+         int result=foo(1,2);  // violation without filter
+ 
+         int myconst  // violation without filter
+-                = foo(9, 2);
++                = foo(1, 2);
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/context/defaultContextConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FinalLocalVariable">
+            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="FinalLocalVariableCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/context/expected.txt
@@ -1,0 +1,4 @@
+Test.java:8:39: Variable 'args' should be declared final.
+Test.java:14:13: Variable 'myconst' should be declared final.
+Test.java:12:13: Variable 'result' should be declared final.
+Test.java:4:31: Variable 'y' should be declared final.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/newline/Test.java
@@ -1,0 +1,17 @@
+package TreeWalker.coding.FinalLocalVariable;
+
+public class Test {
+    static int foo(int x, int y) {  // violation without filter
+        x = 1;
+        return x+y;
+    }
+    public static void main (String []args) {  // violation without filter
+        for (String i : args) {
+            System.out.println(i);
+        }
+        int result=foo(1,2);  // violation without filter
+
+        int myconst  // violation without filter
+                = foo(1, 2);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/newline/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 618536b..7d45dea 100644
+--- a/Test.java
++++ b/Test.java
+@@ -12,6 +12,6 @@ public class Test {
+         int result=foo(1,2);  // violation without filter
+ 
+         int myconst  // violation without filter
+-                = foo(9, 2);
++                = foo(1, 2);
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/newline/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FinalLocalVariable">
+            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/patchedline/Test.java
@@ -1,0 +1,17 @@
+package TreeWalker.coding.FinalLocalVariable;
+
+public class Test {
+    static int foo(int x, int y) {  // violation without filter
+        x = 1;
+        return x+y;
+    }
+    public static void main (String []args) {  // violation without filter
+        for (String i : args) {
+            System.out.println(i);
+        }
+        int result=foo(1,2);  // violation without filter
+
+        int myconst  // violation without filter
+                = foo(1, 2);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/patchedline/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 618536b..7d45dea 100644
+--- a/Test.java
++++ b/Test.java
+@@ -12,6 +12,6 @@ public class Test {
+         int result=foo(1,2);  // violation without filter
+ 
+         int myconst  // violation without filter
+-                = foo(9, 2);
++                = foo(1, 2);
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/FinalLocalVariable/case2/patchedline/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FinalLocalVariable">
+            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>


### PR DESCRIPTION
Issue #163: SuppressionPatchXpathFilter: FinalLocalVariable's contextstrategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665554887
similar https://github.com/checkstyle/patch-filters/pull/130#issue-455110382, the violation node is IDENT -> x [4:23] and IDENT -> y [4:30] not METHOD_DEF -> METHOD_DEF [4:4].

```
 |--METHOD_DEF -> METHOD_DEF [4:4]
    |   |--MODIFIERS -> MODIFIERS [4:4]
    |   |   `--LITERAL_STATIC -> static [4:4]
    |   |--TYPE -> TYPE [4:11]
    |   |   `--LITERAL_INT -> int [4:11]
    |   |--IDENT -> foo [4:15]
    |   |--LPAREN -> ( [4:18]
    |   |--PARAMETERS -> PARAMETERS [4:19]
    |   |   |--PARAMETER_DEF -> PARAMETER_DEF [4:19]
    |   |   |   |--MODIFIERS -> MODIFIERS [4:19]
    |   |   |   |--TYPE -> TYPE [4:19]
    |   |   |   |   `--LITERAL_INT -> int [4:19]
    |   |   |   `--IDENT -> x [4:23]
    |   |   |--COMMA -> , [4:24]
    |   |   `--PARAMETER_DEF -> PARAMETER_DEF [4:26]
    |   |       |--MODIFIERS -> MODIFIERS [4:26]
    |   |       |--TYPE -> TYPE [4:26]
    |   |       |   `--LITERAL_INT -> int [4:26]
    |   |       `--IDENT -> y [4:30]
    |   |--RPAREN -> ) [4:31]
    |   `--SLIST -> { [4:33]

```

<img width="559" alt="image" src="https://user-images.githubusercontent.com/50866227/88672743-614ccf00-d11a-11ea-9190-475e34aa88d0.png">

violation is node IDENT -> myconst [14:12], `= foo(1, 2);` are not its child nodes, so this violation is suppressed but should not.
