### PR TITLE
Issue #164: SuppressionPatchXpathFilter: HiddenField's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -225,6 +225,14 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testHiddenField() throws Exception {
+        testByConfig("HiddenField/newline/defaultContextConfig.xml");
+        testByConfig("HiddenField/patchedline/defaultContextConfig.xml");
+        testByConfig("HiddenField/context/defaultContextConfig.xml");
+        testByConfig("HiddenField/context/case2/defaultContextConfig.xml");
+    }
+
+    @Test
     @Ignore("JavadocMethod should have a violation, but not. It should be solved by"
             + "context strategy.")
     public void testJavadocMethod() throws Exception {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/Test.java
@@ -1,0 +1,15 @@
+package TreeWalker.coding.HiddenField;
+
+public class Test {
+    private int test;
+
+    private void addTest(int test)  // violation without filter
+    {
+        System.out.println(test);
+    }
+
+    private void foo()
+    {
+        final int test = 1;  // violation without filter
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/case2/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/case2/Test.java
@@ -1,0 +1,15 @@
+package TreeWalker.coding.HiddenField;
+
+public class Test {
+    private int test;
+
+    private void addTest(int test)  // violation without filter
+    {
+        System.out.println(test);
+    }
+
+    private void foo()
+    {
+        final int test = 1;  // violation without filter
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/case2/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/case2/defaultContext.patch
@@ -1,0 +1,20 @@
+diff --git a/Test.java b/Test.java
+index 7b3fdb2..1b589c2 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,6 +1,7 @@
+ package TreeWalker.coding.HiddenField;
+ 
+ public class Test {
++    private int test;
+ 
+     private void addTest(int test)  // violation without filter
+     {
+@@ -9,6 +10,6 @@ public class Test {
+ 
+     private void foo()
+     {
+-        final int test1 = 1;
++        final int test = 1;  // violation without filter
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/case2/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/case2/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="HiddenField"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="supportContextStrategyChecks" value="HiddenField" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/case2/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/case2/expected.txt
@@ -1,0 +1,1 @@
+Test.java:13:19: 'test' hides a field.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index f9f6c5b..7e271c5 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,6 +1,7 @@
+ package TreeWalker.coding.HiddenField;
+ 
+ public class Test {
++    private int test;
+ 
+     private void addTest(int test)  // violation without filter
+     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="HiddenField"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="HiddenFieldCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/context/expected.txt
@@ -1,0 +1,2 @@
+Test.java:13:19: 'test' hides a field.
+Test.java:6:30: 'test' hides a field.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/newline/Test.java
@@ -1,0 +1,20 @@
+package TreeWalker.coding.HiddenField;
+
+public class Test {
+    private int test;
+
+    private void addTest(int test)  // violation without filter
+    {
+        System.out.println(test);
+    }
+
+    private void addTest1(int test)  // violation without filter
+    {
+        System.out.println(test);
+    }
+
+    private void foo()
+    {
+        final int test = 1;  // violation without filter
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/newline/defaultContext.patch
@@ -1,0 +1,16 @@
+diff --git a//Test.java b//Test.java
+index 7e271c5..2efb892 100644
+--- a//Test.java
++++ b//Test.java
+@@ -8,6 +8,11 @@ public class Test {
+         System.out.println(test);
+     }
+ 
++    private void addTest1(int test)  // violation without filter
++    {
++        System.out.println(test);
++    }
++
+     private void foo()
+     {
+         final int test = 1;  // violation without filter

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="HiddenField"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:11:31: 'test' hides a field.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/patchedline/Test.java
@@ -1,0 +1,20 @@
+package TreeWalker.coding.HiddenField;
+
+public class Test {
+    private int test;
+
+    private void addTest(int test)  // violation without filter
+    {
+        System.out.println(test);
+    }
+
+    private void addTest1(int test)  // violation without filter
+    {
+        System.out.println(test);
+    }
+
+    private void foo()
+    {
+        final int test = 1;  // violation without filter
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/patchedline/defaultContext.patch
@@ -1,0 +1,16 @@
+diff --git a//Test.java b//Test.java
+index 7e271c5..2efb892 100644
+--- a//Test.java
++++ b//Test.java
+@@ -8,6 +8,11 @@ public class Test {
+         System.out.println(test);
+     }
+ 
++    private void addTest1(int test)  // violation without filter
++    {
++        System.out.println(test);
++    }
++
+     private void foo()
+     {
+         final int test = 1;  // violation without filter

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="HiddenField"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/HiddenField/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:11:31: 'test' hides a field.


### PR DESCRIPTION
Issue #164: SuppressionPatchXpathFilter: HiddenField's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665565892

one problem: 
```
public class Test {
+    private int test;
 
     private void addTest(int test)  // violation context
     {
```
this added line is not the child nodes of `test` violations' node.