### PR TITLE
Issue #180: SuppressionPatchXpathFilter: SuperClone's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -308,4 +308,11 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
         testByConfig("CovariantEquals/patchedline/defaultContextConfig.xml");
         testByConfig("CovariantEquals/context/defaultContextConfig.xml");
     }
+
+    @Test
+    public void testSuperClone() throws Exception {
+        testByConfig("SuperClone/newline/defaultContextConfig.xml");
+        testByConfig("SuperClone/patchedline/defaultContextConfig.xml");
+        testByConfig("SuperClone/context/defaultContextConfig.xml");
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/context/Test.java
@@ -1,0 +1,20 @@
+package TreeWalker.coding.SuperClone;
+
+public class Test {
+    public Object clone() throws CloneNotSupportedException {  // violation without filter
+        return new Object();
+    }
+}
+
+class Test1 {
+    public Object clone() throws CloneNotSupportedException {  // violation without filter
+        return new Object();
+    }
+}
+
+class Test2 {
+    public Integer clone() throws CloneNotSupportedException {
+        return (Integer) super.clone();
+    }
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/context/defaultContext.patch
@@ -1,0 +1,19 @@
+diff --git a/Test.java b/Test.java
+index 6d5e669..ecb7271 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,13 +2,12 @@ package TreeWalker.coding.SuperClone;
+ 
+ public class Test {
+     public Object clone() throws CloneNotSupportedException {  // violation without filter
+-        return super.clone();
++        return new Object();
+     }
+ }
+ 
+ class Test1 {
+     public Object clone() throws CloneNotSupportedException {  // violation without filter
+-        System.out.println();
+         return new Object();
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="SuperClone"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="checkNamesForContextStrategyByTokenOrParentSet" value="SuperCloneCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/context/expected.txt
@@ -1,0 +1,2 @@
+Test.java:10:19: Method 'clone' should call 'super.clone'.
+Test.java:4:19: Method 'clone' should call 'super.clone'.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/newline/Test.java
@@ -1,0 +1,26 @@
+package TreeWalker.coding.SuperClone;
+
+public class Test {
+    public Object clone() throws CloneNotSupportedException {  // violation without filter
+        return new Object();
+    }
+}
+
+class Test1 {
+    public Object clone() throws CloneNotSupportedException  {  // violation without filter
+        return new Object();
+    }
+}
+
+class Test2 {
+    public Integer clone() throws CloneNotSupportedException {
+        return (Integer) super.clone();
+    }
+}
+
+class Test3 {
+    public Object clone() throws CloneNotSupportedException {  // violation without filter
+        return new Object();
+    }
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/newline/defaultContext.patch
@@ -1,0 +1,23 @@
+diff --git a/Test.java b/Test.java
+index ecb7271..b06042d 100644
+--- a/Test.java
++++ b/Test.java
+@@ -7,7 +7,7 @@ public class Test {
+ }
+ 
+ class Test1 {
+-    public Object clone() throws CloneNotSupportedException {  // violation without filter
++    public Object clone() throws CloneNotSupportedException  {  // violation without filter
+         return new Object();
+     }
+ }
+@@ -18,3 +18,9 @@ class Test2 {
+     }
+ }
+ 
++class Test3 {
++    public Object clone() throws CloneNotSupportedException {  // violation without filter
++        return new Object();
++    }
++}
++

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="SuperClone"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:22:19: Method 'clone' should call 'super.clone'.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/patchedline/Test.java
@@ -1,0 +1,26 @@
+package TreeWalker.coding.SuperClone;
+
+public class Test {
+    public Object clone() throws CloneNotSupportedException {  // violation without filter
+        return new Object();
+    }
+}
+
+class Test1 {
+    public Object clone() throws CloneNotSupportedException  {  // violation without filter
+        return new Object();
+    }
+}
+
+class Test2 {
+    public Integer clone() throws CloneNotSupportedException {
+        return (Integer) super.clone();
+    }
+}
+
+class Test3 {
+    public Object clone() throws CloneNotSupportedException {  // violation without filter
+        return new Object();
+    }
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/patchedline/defaultContext.patch
@@ -1,0 +1,23 @@
+diff --git a/Test.java b/Test.java
+index ecb7271..b06042d 100644
+--- a/Test.java
++++ b/Test.java
+@@ -7,7 +7,7 @@ public class Test {
+ }
+ 
+ class Test1 {
+-    public Object clone() throws CloneNotSupportedException {  // violation without filter
++    public Object clone() throws CloneNotSupportedException  {  // violation without filter
+         return new Object();
+     }
+ }
+@@ -18,3 +18,9 @@ class Test2 {
+     }
+ }
+ 
++class Test3 {
++    public Object clone() throws CloneNotSupportedException {  // violation without filter
++        return new Object();
++    }
++}
++

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="SuperClone"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/SuperClone/patchedline/expected.txt
@@ -1,0 +1,2 @@
+Test.java:10:19: Method 'clone' should call 'super.clone'.
+Test.java:22:19: Method 'clone' should call 'super.clone'.


### PR DESCRIPTION
Issue #180: SuppressionPatchXpathFilter: SuperClone's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665554887
ignore reason is that:

`Test.java:10:19: Method 'clone' should call 'super.clone'.`, the violation node is IDENT -> clone [10:18] not METHOD_DEF -> METHOD_DEF [10:4], so context strategy that check whether child nodes changed will not work.

it it the same with https://github.com/checkstyle/patch-filters/pull/130#discussion_r460881245, 

>lets make method like isParentOfAbstractToken and if it return true - use both nodes in match.

but I am not clear how to know whether a node is a abstract node, please give me more information.

```
|--METHOD_DEF -> METHOD_DEF [10:4]
    |   |--MODIFIERS -> MODIFIERS [10:4]
    |   |   `--LITERAL_PUBLIC -> public [10:4]
    |   |--TYPE -> TYPE [10:11]
    |   |   `--IDENT -> Object [10:11]
    |   |--IDENT -> clone [10:18]
    |   |--LPAREN -> ( [10:23]
    |   |--PARAMETERS -> PARAMETERS [10:24]
    |   |--RPAREN -> ) [10:24]
    |   |--LITERAL_THROWS -> throws [10:26]
    |   |   `--IDENT -> CloneNotSupportedException [10:33]
    |   `--SLIST -> { [10:60]
    |       |--LITERAL_RETURN -> return [11:8]
    |       |   |--EXPR -> EXPR [11:15]
    |       |   |   `--LITERAL_NEW -> new [11:15]
    |       |   |       |--IDENT -> Object [11:19]
    |       |   |       |--LPAREN -> ( [11:25]
    |       |   |       |--ELIST -> ELIST [11:26]
    |       |   |       `--RPAREN -> ) [11:26]
    |       |   `--SEMI -> ; [11:27]
    |       `--RCURLY -> } [12:4]

```