### PR TITLE
Issue #182: SuppressionPatchXpathFilter: UnnecessarySemicolonInEnumeration's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -509,4 +509,11 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
         testByConfig("PackageDeclaration/patchedline/defaultContextConfig.xml");
         testByConfig("PackageDeclaration/context/defaultContextConfig.xml");
     }
+
+    @Test
+    public void testUnnecessarySemicolonInEnumeration() throws Exception {
+        testByConfig("UnnecessarySemicolonInEnumeration/newline/defaultContextConfig.xml");
+        testByConfig("UnnecessarySemicolonInEnumeration/patchedline/defaultContextConfig.xml");
+        testByConfig("UnnecessarySemicolonInEnumeration/context/defaultContextConfig.xml");
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/context/Test.java
@@ -1,0 +1,30 @@
+package TreeWalker.coding.UnnecessarySemicolonInEnumeration;
+
+public class Test {
+    enum One {
+        A,B,;  // violation without filter
+    }
+    enum Two {
+        A,;  // violation without filter
+    }
+    enum Three {
+        A,B();  // violation without filter
+    }
+    enum Four {
+        A,B{};  // violation without filter
+    }
+    enum Five {
+        A,
+        B
+        ;  // violation without filter
+    }
+
+    enum six {
+        A,
+        B,
+        ;  // violation without filter
+    }
+    enum seven {
+        A, B
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/context/defaultContext.patch
@@ -1,0 +1,25 @@
+diff --git a/Test.java b/Test.java
+index cf2814c..1773bcb 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,10 +2,10 @@ package TreeWalker.coding.UnnecessarySemicolonInEnumeration;
+ 
+ public class Test {
+     enum One {
+-        A,B
++        A,B,;  // violation without filter
+     }
+     enum Two {
+-        A,B,;
++        A,;  // violation without filter
+     }
+     enum Three {
+         A,B();  // violation without filter
+@@ -23,7 +23,6 @@ public class Test {
+         A,
+         B,
+         ;  // violation without filter
+-        six(){}
+     }
+     enum seven {
+         A, B

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="UnnecessarySemicolonInEnumeration"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="checkNamesForContextStrategyByTokenOrParentSet" value="UnnecessarySemicolonInEnumerationCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/context/expected.txt
@@ -1,0 +1,3 @@
+Test.java:25:9: Unnecessary semicolon.
+Test.java:5:13: Unnecessary semicolon.
+Test.java:8:11: Unnecessary semicolon.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/newline/Test.java
@@ -1,0 +1,16 @@
+package TreeWalker.coding.UnnecessarySemicolonInEnumeration;
+
+public class Test {
+    enum One {
+        A,B,;  // violation without filter
+    }
+    enum Two {
+        A,;  // violation without filter
+    }
+    enum Three {
+        A,B();
+    }
+    enum Four {
+        A,B,;  // violation without filter
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/newline/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 282fb80..6ad6ae5 100644
+--- a/Test.java
++++ b/Test.java
+@@ -10,4 +10,7 @@ public class Test {
+     enum Three {
+         A,B();  // violation without filter
+     }
++    enum Four {
++        A,B,;  // violation without filter
++    }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="UnnecessarySemicolonInEnumeration"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:14:13: Unnecessary semicolon.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/patchedline/Test.java
@@ -1,0 +1,30 @@
+package TreeWalker.coding.UnnecessarySemicolonInEnumeration;
+
+public class Test {
+    enum One {
+        A,B,;  // violation without filter
+    }
+    enum Two {
+        A,;  // violation without filter
+    }
+    enum Three {
+        A,B();  // violation without filter
+    }
+    enum Four {
+        A,B{};  // violation without filter
+    }
+    enum Five {
+        A,
+        B
+        ;  // violation without filter
+    }
+
+    enum six {
+        A,
+        B,
+        ;  // violation without filter
+    }
+    enum seven {
+        A, B
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/patchedline/defaultContext.patch
@@ -1,0 +1,25 @@
+diff --git a/Test.java b/Test.java
+index cf2814c..1773bcb 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,10 +2,10 @@ package TreeWalker.coding.UnnecessarySemicolonInEnumeration;
+ 
+ public class Test {
+     enum One {
+-        A,B
++        A,B,;  // violation without filter
+     }
+     enum Two {
+-        A,B,;
++        A,;  // violation without filter
+     }
+     enum Three {
+         A,B();  // violation without filter
+@@ -23,7 +23,6 @@ public class Test {
+         A,
+         B,
+         ;  // violation without filter
+-        six(){}
+     }
+     enum seven {
+         A, B

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="UnnecessarySemicolonInEnumeration"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/UnnecessarySemicolonInEnumeration/patchedline/expected.txt
@@ -1,0 +1,2 @@
+Test.java:5:13: Unnecessary semicolon.
+Test.java:8:11: Unnecessary semicolon.


### PR DESCRIPTION
Issue #182: SuppressionPatchXpathFilter: UnnecessarySemicolonInEnumeration's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665554887

one problem:

```
         A,
         B,
         ;
-        six(){}
     }
```
`six(){}` cause the violation, but it is not child node of ` ;`