### PR TITLE
Issue #187: SuppressionPatchXpathFilter:VariableDeclarationUsageDistance's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -52,6 +52,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testVariableDeclarationUsageDistance() throws Exception {
+        testByConfig("VariableDeclarationUsageDistance/newline/defaultContextConfig.xml");
+        testByConfig("VariableDeclarationUsageDistance/patchedline/defaultContextConfig.xml");
+        testByConfig("VariableDeclarationUsageDistance/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testIllegalToken() throws Exception {
         testByConfig(
                 "IllegalToken/newline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/context/Test.java
@@ -1,0 +1,12 @@
+package TreeWalker.VariableDeclarationUsageDistance;
+
+public class Test {
+    public void test(int a, int b) {
+        int count;
+        a = a + b;
+        b = a + a;
+        System.out.println(a);
+        System.out.println(b);
+        count = b;  // violation context
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/context/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 343bb6c..d706ba4 100644
+--- a/Test.java
++++ b/Test.java
+@@ -6,6 +6,7 @@ public class Test {
+         a = a + b;
+         b = a + a;
+         System.out.println(a);
++        System.out.println(b);
+         count = b;  // violation context
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="VariableDeclarationUsageDistance"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="VariableDeclarationUsageDistanceCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/context/expected.txt
@@ -1,0 +1,1 @@
+Test.java:5: Distance between variable 'count' declaration and its first usage is 5, but allowed 3.  Consider making that variable final if you still need to store its value in advance (before method calls that might have side effects on the original value).

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/newline/Test.java
@@ -1,0 +1,14 @@
+package TreeWalker.VariableDeclarationUsageDistance;
+
+public class Test {
+    public void test(int a, int b) {
+        int count;
+        int size;
+        a = a + b;
+        b = a + a;
+        System.out.println(a);
+        System.out.println(b);
+        count = b;  // violation without filter
+        size = b;  // violation without filter
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/newline/defaultContext.patch
@@ -1,0 +1,18 @@
+diff --git a/Test.java b/Test.java
+index d706ba4..a713696 100644
+--- a/Test.java
++++ b/Test.java
+@@ -3,10 +3,12 @@ package TreeWalker.VariableDeclarationUsageDistance;
+ public class Test {
+     public void test(int a, int b) {
+         int count;
++        int size;
+         a = a + b;
+         b = a + a;
+         System.out.println(a);
+         System.out.println(b);
+         count = b;  // violation without filter
++        size = b;  // violation without filter
+     }
+ }
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="VariableDeclarationUsageDistance"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:6: Distance between variable 'size' declaration and its first usage is 6, but allowed 3.  Consider making that variable final if you still need to store its value in advance (before method calls that might have side effects on the original value).

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/patchedline/Test.java
@@ -1,0 +1,14 @@
+package TreeWalker.VariableDeclarationUsageDistance;
+
+public class Test {
+    public void test(int a, int b) {
+        int count;
+        int size;
+        a = a + b;
+        b = a + a;
+        System.out.println(a);
+        System.out.println(b);
+        count = b;  // violation without filter
+        size = b;  // violation without filter
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/patchedline/defaultContext.patch
@@ -1,0 +1,17 @@
+diff --git a/Test.java b/Test.java
+index d706ba4..a713696 100644
+--- a/Test.java
++++ b/Test.java
+@@ -3,10 +3,12 @@ package TreeWalker.VariableDeclarationUsageDistance;
+ public class Test {
+     public void test(int a, int b) {
+         int count;
++        int size;
+         a = a + b;
+         b = a + a;
+         System.out.println(a);
+         System.out.println(b);
+         count = b;  // violation without filter
++        size = b;  // violation without filter
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="VariableDeclarationUsageDistance"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/VariableDeclarationUsageDistance/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:6: Distance between variable 'size' declaration and its first usage is 6, but allowed 3.  Consider making that variable final if you still need to store its value in advance (before method calls that might have side effects on the original value).


### PR DESCRIPTION
Issue #187: SuppressionPatchXpathFilter:VariableDeclarationUsageDistance's context strategy

this problem belongs to common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665565892

```
         a = a + b;
         b = a + a;
         System.out.println(a);
+        System.out.println(b);
         count = b;  // violation context
     }
```
`System.out.println(b);` are not child nodes of `count = b;`