### PR TITLE
Issue #191: SuppressionPatchXpathFilter: InnerTypeLast's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -108,6 +108,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testInnerTypeLast() throws Exception {
+        testByConfig("InnerTypeLast/newline/defaultContextConfig.xml");
+        testByConfig("InnerTypeLast/patchedline/defaultContextConfig.xml");
+        testByConfig("InnerTypeLast/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testMagicNumber() throws Exception {
         testByConfig(
                 "MagicNumber/newline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/context/Test.java
@@ -1,0 +1,16 @@
+package TreeWalker.InnerTypeLast;
+
+public class Test {
+}
+
+class Test1 {
+    private String s; // OK
+    class InnerTest1 {}
+    public void test() {} // violation without filter
+}
+
+class Test2 {
+    private String s; // OK
+    class InnerTest1 {}
+    public void test() {} // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/context/defaultContext.patch
@@ -1,0 +1,18 @@
+diff --git a/Test.java b/Test.java
+index 8968f94..3ed22b2 100644
+--- a/Test.java
++++ b/Test.java
+@@ -5,11 +5,12 @@ public class Test {
+ 
+ class Test1 {
+     private String s; // OK
++    class InnerTest1 {}
+     public void test() {} // violation without filter
+ }
+ 
+ class Test2 {
+     private String s; // OK
+-    public void InnerTest1() {}
++    class InnerTest1 {}
+     public void test() {} // violation without filter
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="InnerTypeLast"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="InnerTypeLastCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/context/expected.txt
@@ -1,0 +1,2 @@
+Test.java:15:5: Fields and methods should be before inner classes.
+Test.java:9:5: Fields and methods should be before inner classes.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/newline/Test.java
@@ -1,0 +1,17 @@
+package TreeWalker.InnerTypeLast;
+
+public class Test {
+}
+
+class Test1 {
+    private String s; // OK
+    class InnerTest1 {}
+    public void test1() {} // violation without filter
+}
+
+class Test2 {
+    private String s; // OK
+    class InnerTest1 {}
+    public void test() {} // violation without filter
+    public void test1() {} // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/newline/defaultContext.patch
@@ -1,0 +1,18 @@
+diff --git a/Test.java b/Test.java
+index 3ed22b2..b386e89 100644
+--- a/Test.java
++++ b/Test.java
+@@ -6,11 +6,12 @@ public class Test {
+ class Test1 {
+     private String s; // OK
+     class InnerTest1 {}
+-    public void test() {} // violation without filter
++    public void test1() {} // violation without filter
+ }
+ 
+ class Test2 {
+     private String s; // OK
+     class InnerTest1 {}
+     public void test() {} // violation without filter
++    public void test1() {} // violation without filter
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="InnerTypeLast"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:16:5: Fields and methods should be before inner classes.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/patchedline/Test.java
@@ -1,0 +1,17 @@
+package TreeWalker.InnerTypeLast;
+
+public class Test {
+}
+
+class Test1 {
+    private String s; // OK
+    class InnerTest1 {}
+    public void test1() {} // violation without filter
+}
+
+class Test2 {
+    private String s; // OK
+    class InnerTest1 {}
+    public void test() {} // violation without filter
+    public void test1() {} // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/patchedline/defaultContext.patch
@@ -1,0 +1,18 @@
+diff --git a/Test.java b/Test.java
+index 3ed22b2..b386e89 100644
+--- a/Test.java
++++ b/Test.java
+@@ -6,11 +6,12 @@ public class Test {
+ class Test1 {
+     private String s; // OK
+     class InnerTest1 {}
+-    public void test() {} // violation without filter
++    public void test1() {} // violation without filter
+ }
+ 
+ class Test2 {
+     private String s; // OK
+     class InnerTest1 {}
+     public void test() {} // violation without filter
++    public void test1() {} // violation without filter
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="InnerTypeLast"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/InnerTypeLast/patchedline/expected.txt
@@ -1,0 +1,2 @@
+Test.java:16:5: Fields and methods should be before inner classes.
+Test.java:9:5: Fields and methods should be before inner classes.


### PR DESCRIPTION
Issue #191: SuppressionPatchXpathFilter: InnerTypeLast's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665565892
```
 class Test1 {
     private String s; // OK
+    class InnerTest1 {}
     public void test() {} // violation context
 }
 
 class Test2 {
     private String s; // OK
-    public void InnerTest1() {}
+    class InnerTest1 {}
     public void test() {} // violation context
```
add/delete/change some nodes, then it will cause a violation, but these add/delete/change nodes are not violation node's child node, so current strategy not work.