### PR TITLE
Issue #197: SuppressionPatchXpathFilter: NoCodeInFile's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -222,6 +222,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testNoCodeInFile() throws Exception {
+        testByConfig("NoCodeInFile/newline/defaultContextConfig.xml");
+        testByConfig("NoCodeInFile/patchedline/defaultContextConfig.xml");
+        testByConfig("NoCodeInFile/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testOuterTypeNumber() throws Exception {
         testByConfig("sizes/OuterTypeNumber/newline/defaultContextConfig.xml");
         testByConfig("sizes/OuterTypeNumber/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/context/Test.java
@@ -1,0 +1,5 @@
+/* only  // violation without filter
+comment
+add one line
+present
+*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/context/defaultContext.patch
@@ -1,0 +1,10 @@
+diff --git a/Test.java b/Test.java
+index c820703..4d34f09 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,4 +1,5 @@
+ /* only  // violation without filter
+ comment
++add one line
+ present
+ */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="NoCodeInFile"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="NoCodeInFileCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/context/expected.txt
@@ -1,0 +1,1 @@
+Test.java:1: The file does not contain any code.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/newline/Test.java
@@ -1,0 +1,5 @@
+/* only  // violation without filter
+comment
+add one line
+present
+*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/newline/defaultContext.patch
@@ -1,0 +1,10 @@
+diff --git a/Test.java b/Test.java
+index c820703..4d34f09 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,4 +1,5 @@
+ /* only  // violation without filter
+ comment
++add one line
+ present
+ */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/newline/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="NoCodeInFile"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+            <property name="neverSuppressedChecks" value="NoCodeInFileCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:1: The file does not contain any code.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/patchedline/Test.java
@@ -1,0 +1,5 @@
+/* only  // violation without filter
+comment
+add one line
+present
+*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/patchedline/defaultContext.patch
@@ -1,0 +1,10 @@
+diff --git a/Test.java b/Test.java
+index c820703..4d34f09 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,4 +1,5 @@
+ /* only  // violation without filter
+ comment
++add one line
+ present
+ */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/patchedline/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="NoCodeInFile"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+            <property name="neverSuppressedChecks" value="NoCodeInFileCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/NoCodeInFile/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:1: The file does not contain any code.


### PR DESCRIPTION
Issue #197: SuppressionPatchXpathFilter: NoCodeInFile's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-667061679

```
 /* only
 comment
+add one line
 present
 */
```
the violation line always is `1:`,  and this violation is the whole file only.