### PR TITLE
Issue #204: SuppressionPatchXpathFilter: EmptyLineSeparator's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -133,6 +133,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testEmptyLineSeparator() throws Exception {
+        testByConfig("EmptyLineSeparator/newline/defaultContextConfig.xml");
+        testByConfig("EmptyLineSeparator/patchedline/defaultContextConfig.xml");
+        testByConfig("EmptyLineSeparator/context/defaultContextConfig.xml");
+    }
+
+    @Test
     @Ignore("JavadocMethod should have a violation, but not. It should be solved by"
             + "context strategy.")
     public void testJavadocMethod() throws Exception {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/context/Test.java
@@ -1,0 +1,9 @@
+///////////////////////////////////////////////////
+//HEADER
+///////////////////////////////////////////////////
+package TreeWalker.EmptyLineSeparator;  // violation without filter
+
+public class Test {
+    public static final int FOO_CONST = 1;
+    public void foo() {}  // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/context/defaultContext.patch
@@ -1,0 +1,16 @@
+diff --git a/Test.java b/Test.java
+index ebee1d9..f3825c2 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,11 +1,9 @@
+ ///////////////////////////////////////////////////
+ //HEADER
+ ///////////////////////////////////////////////////
+-
+ package TreeWalker.EmptyLineSeparator;  // violation without filter
+ 
+ public class Test {
+     public static final int FOO_CONST = 1;
+-
+     public void foo() {}  // violation without filter
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="EmptyLineSeparator"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="EmptyLineSeparatorCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/context/expected.txt
@@ -1,0 +1,2 @@
+Test.java:4: 'package' should be separated from previous statement.
+Test.java:8: 'METHOD_DEF' should be separated from previous statement.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/newline/Test.java
@@ -1,0 +1,10 @@
+///////////////////////////////////////////////////
+//HEADER
+///////////////////////////////////////////////////
+package TreeWalker.EmptyLineSeparator;  // violation without filter
+
+public class Test {
+    public static final int FOO_CONST = 1;
+    public void foo() {}  // violation without filter
+    public void foo2() {}  // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/newline/defaultContext.patch
@@ -1,0 +1,10 @@
+diff --git a/Test.java b/Test.java
+index f3825c2..4441b50 100644
+--- a/Test.java
++++ b/Test.java
+@@ -6,4 +6,5 @@ package TreeWalker.EmptyLineSeparator;  // violation without filter
+ public class Test {
+     public static final int FOO_CONST = 1;
+     public void foo() {}  // violation without filter
++    public void foo2() {}  // violation without filter
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="EmptyLineSeparator"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:9: 'METHOD_DEF' should be separated from previous statement.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/patchedline/Test.java
@@ -1,0 +1,10 @@
+///////////////////////////////////////////////////
+//HEADER
+///////////////////////////////////////////////////
+package TreeWalker.EmptyLineSeparator;  // violation without filter
+
+public class Test {
+    public static final int FOO_CONST = 1;
+    public void foo() {}  // violation without filter
+    public void foo2() {}  // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/patchedline/defaultContext.patch
@@ -1,0 +1,10 @@
+diff --git a/Test.java b/Test.java
+index f3825c2..4441b50 100644
+--- a/Test.java
++++ b/Test.java
+@@ -6,4 +6,5 @@ package TreeWalker.EmptyLineSeparator;  // violation without filter
+ public class Test {
+     public static final int FOO_CONST = 1;
+     public void foo() {}  // violation without filter
++    public void foo2() {}  // violation without filter
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="EmptyLineSeparator"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/EmptyLineSeparator/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:9: 'METHOD_DEF' should be separated from previous statement.


### PR DESCRIPTION
Issue #204: SuppressionPatchXpathFilter: EmptyLineSeparator's context strategy

here is a problem described in https://github.com/checkstyle/patch-filters/issues/203

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-665565892