### PR TITLE
Issue #222: Remove ALWAYS_MATCHING_CONTEXT_STRATEGY_CHECKS from PatchXpathFilterElement

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/PatchXpathFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/PatchXpathFilterElement.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -33,14 +32,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
  * This filter element is immutable and processes.
  */
 public class PatchXpathFilterElement implements TreeWalkerFilter {
-    /**
-     * List of checks that always matching context strategy.
-     */
-    private static final List<String> ALWAYS_MATCHING_CONTEXT_STRATEGY_CHECKS =
-            Arrays.asList("OuterTypeNumberCheck",
-                    "OuterTypeFilenameCheck"
-            );
-
     /**
      * Set of checks that support context strategy but need modify violation nodes
      * to their parent abstract nodes to get their child nodes.
@@ -193,10 +184,7 @@ public class PatchXpathFilterElement implements TreeWalkerFilter {
     private boolean isMatchingByContextStrategy(TreeWalkerAuditEvent event) {
         boolean result = false;
         final String checkShortName = getCheckShortName(event);
-        if (ALWAYS_MATCHING_CONTEXT_STRATEGY_CHECKS.contains(checkShortName)) {
-            result = true;
-        }
-        else if (supportContextStrategyChecks.contains(checkShortName)
+        if (supportContextStrategyChecks.contains(checkShortName)
                 || checkNamesForContextStrategyByTokenOrParentSet.contains(checkShortName)) {
             final DetailAST eventAst;
             if (checkNamesForContextStrategyByTokenOrParentSet.contains(checkShortName)) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -188,12 +188,9 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
 
     @Test
     public void testOuterTypeNumber() throws Exception {
-        testByConfig(
-                "sizes/OuterTypeNumber/newline/defaultContextConfig.xml");
-        testByConfig(
-                "sizes/OuterTypeNumber/patchedline/defaultContextConfig.xml");
-        testByConfig(
-                "sizes/OuterTypeNumber/context/defaultContextConfig.xml");
+        testByConfig("sizes/OuterTypeNumber/newline/defaultContextConfig.xml");
+        testByConfig("sizes/OuterTypeNumber/patchedline/defaultContextConfig.xml");
+        testByConfig("sizes/OuterTypeNumber/context/defaultContextConfig.xml");
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/context/Test1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/context/Test1.java
@@ -1,4 +1,4 @@
 package TreeWalker.OuterTypeFilename;
 
-class Test {  // violation context
+class Test {  // violation
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/context/defaultContextConfig.xml
@@ -9,6 +9,7 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="OuterTypeFilenameCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/newline/Test1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/newline/Test1.java
@@ -1,4 +1,4 @@
 package TreeWalker.OuterTypeFilename;
 
-class Test {  // violation context
+class Test {  // violation
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/newline/defaultContextConfig.xml
@@ -9,6 +9,7 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="newline" />
+            <property name="neverSuppressedChecks" value="OuterTypeFilenameCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/newline/expected.txt
@@ -1,0 +1,1 @@
+Test1.java:3:1: The name of the outer type and the file do not match.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/patchedline/Test1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/patchedline/Test1.java
@@ -1,4 +1,4 @@
 package TreeWalker.OuterTypeFilename;
 
-class Test {  // violation context
+class Test {  // violation
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/patchedline/defaultContextConfig.xml
@@ -9,6 +9,7 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="patchedline" />
+            <property name="neverSuppressedChecks" value="OuterTypeFilenameCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/OuterTypeFilename/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test1.java:3:1: The name of the outer type and the file do not match.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/context/Test.java
@@ -1,4 +1,4 @@
-package TreeWalker.OuterTypeNumber;  // violation context
+package TreeWalker.OuterTypeNumber;  // violation
 
 public class Test {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/context/defaultContextConfig.xml
@@ -11,6 +11,7 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="OuterTypeNumberCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/newline/Test.java
@@ -1,4 +1,4 @@
-package TreeWalker.OuterTypeNumber;  // violation context
+package TreeWalker.OuterTypeNumber;  // violation
 
 public class Test {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/newline/defaultContextConfig.xml
@@ -11,6 +11,7 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="newline" />
+            <property name="neverSuppressedChecks" value="OuterTypeNumberCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:1:1: Outer types defined is 3 (max allowed is 2).

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/patchedline/Test.java
@@ -1,4 +1,4 @@
-package TreeWalker.OuterTypeNumber;  // violation context
+package TreeWalker.OuterTypeNumber;  // violation
 
 public class Test {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/patchedline/defaultContextConfig.xml
@@ -11,6 +11,7 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="patchedline" />
+            <property name="neverSuppressedChecks" value="OuterTypeNumberCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/sizes/OuterTypeNumber/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:1:1: Outer types defined is 3 (max allowed is 2).


### PR DESCRIPTION
Issue #222: Remove ALWAYS_MATCHING_CONTEXT_STRATEGY_CHECKS from PatchXpathFilterElement