### PR TITLE
Issue #262: SuppressionPatchXpathFilter: JavadocMethod's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -233,13 +232,10 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
-    @Ignore("JavadocMethod should have a violation, but not. It should be solved by"
-            + "context strategy.")
     public void testJavadocMethod() throws Exception {
-        testByConfig(
-                "JavadocMethod/newline/defaultContextConfig.xml");
-        testByConfig(
-                "JavadocMethod/patchedline/defaultContextConfig.xml");
+        testByConfig("JavadocMethod/newline/defaultContextConfig.xml");
+        testByConfig("JavadocMethod/patchedline/defaultContextConfig.xml");
+        testByConfig("JavadocMethod/context/defaultContextConfig.xml");
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/context/Test.java
@@ -12,14 +12,6 @@ public class Test {
     }
 
 
-    /**
-     * test
-     * @param arg1 text
-     * @return text
-     */
-    public int test(Integer arg1, Integer arg2) {  // violation without filter
-        return 1;
-    }
 
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/context/defaultContext.patch
@@ -1,0 +1,21 @@
+diff --git a/Test.java b/Test.java
+index 72e912a..4f2a2cf 100644
+--- a/Test.java
++++ b/Test.java
+@@ -7,7 +7,7 @@ public class Test {
+      * @param arg2 text  // violation without filter
+      * @return text
+      */
+-    public int test1(Integer arg1, Integer arg2) {
++    public int test1(Integer arg1) {
+         return 1;
+     }
+ 
+@@ -20,7 +20,6 @@ public class Test {
+     /**
+      * test
+      * @param arg1 text
+-     * @param arg2 text
+      * @return text
+      */
+     public int test2(Integer arg1, Integer arg2) {  // violation without filter

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/context/defaultContextConfig.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="JavadocMethod">
+            <property name="validateThrows" value="true"/>
+            <property name="allowMissingParamTags" value="false"/>
+            <property name="allowMissingReturnTag" value="false"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="JavadocMethodCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/context/expected.txt
@@ -1,0 +1,2 @@
+Test.java:7:8: Unused @param tag for 'arg2'.
+Test.java:25:44: Expected @param tag for 'arg2'.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/newline/defaultContext.patch
@@ -1,21 +1,19 @@
 diff --git a/Test.java b/Test.java
-index 72e912a..4f2a2cf 100644
+index 4f2a2cf..d5e69ba 100644
 --- a/Test.java
 +++ b/Test.java
-@@ -7,7 +7,7 @@ public class Test {
-      * @param arg2 text  // violation without filter
-      * @return text
-      */
--    public int test1(Integer arg1, Integer arg2) {
-+    public int test1(Integer arg1) {
-         return 1;
+@@ -12,6 +12,14 @@ public class Test {
      }
  
-@@ -20,7 +20,6 @@ public class Test {
-     /**
-      * test
-      * @param arg1 text
--     * @param arg2 text
-      * @return text
-      */
-     public int test2(Integer arg1, Integer arg2) {  // violation
+ 
++    /**
++     * test
++     * @param arg1 text
++     * @return text
++     */
++    public int test(Integer arg1, Integer arg2) {  // violation without filter
++        return 1;
++    }
+ 
+ 
+ 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/newline/expected.txt
@@ -1,2 +1,1 @@
-Test.java:7:8: Unused @param tag for 'arg2'.
-Test.java:25:44: Expected @param tag for 'arg2'.
+Test.java:20:43: Expected @param tag for 'arg2'.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/Test.java
@@ -12,6 +12,14 @@ public class Test {
     }
 
 
+    /**
+     * test
+     * @param arg1 text
+     * @return text
+     */
+    public int test(Integer arg1, Integer arg2) {  // violation without filter
+        return 1;
+    }
 
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/defaultContext.patch
@@ -1,21 +1,19 @@
 diff --git a/Test.java b/Test.java
-index 72e912a..4f2a2cf 100644
+index 4f2a2cf..d5e69ba 100644
 --- a/Test.java
 +++ b/Test.java
-@@ -7,7 +7,7 @@ public class Test {
-      * @param arg2 text  // violation without filter
-      * @return text
-      */
--    public int test1(Integer arg1, Integer arg2) {
-+    public int test1(Integer arg1) {
-         return 1;
+@@ -12,6 +12,14 @@ public class Test {
      }
  
-@@ -20,7 +20,6 @@ public class Test {
-     /**
-      * test
-      * @param arg1 text
--     * @param arg2 text
-      * @return text
-      */
-     public int test2(Integer arg1, Integer arg2) {  // violation without filter
+ 
++    /**
++     * test
++     * @param arg1 text
++     * @return text
++     */
++    public int test(Integer arg1, Integer arg2) {  // violation without filter
++        return 1;
++    }
+ 
+ 
+ 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocMethod/patchedline/expected.txt
@@ -1,2 +1,1 @@
-Test.java:7:8: Unused @param tag for 'arg2'.
-Test.java:25:44: Expected @param tag for 'arg2'.
+Test.java:20:43: Expected @param tag for 'arg2'.


### PR DESCRIPTION
Issue #262: SuppressionPatchXpathFilter: JavadocMethod's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-669225569