### PR TITLE
Issue #267: SuppressionPatchXpathFilter: JavadocParagraph's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -123,6 +123,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testJavadocParagraph() throws Exception {
+        testByConfig("JavadocParagraph/newline/defaultContextConfig.xml");
+        testByConfig("JavadocParagraph/patchedline/defaultContextConfig.xml");
+        testByConfig("JavadocParagraph/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testMissingCtor() throws Exception {
         testByConfig("MissingCtor/newline/defaultContextConfig.xml");
         testByConfig("MissingCtor/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/context/Test.java
@@ -1,0 +1,10 @@
+package TreeWalker.javadoc.JavadocParagraph;
+
+/**
+ * No tag (ok).
+ *
+ * <p>Tag immediately before the text.
+ * <p>No blank line before the tag.  // violation without filter
+ */
+public class Test {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/context/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index b487ae8..ecc14bd 100644
+--- a/Test.java
++++ b/Test.java
+@@ -4,7 +4,6 @@ package TreeWalker.javadoc.JavadocParagraph;
+  * No tag (ok).
+  *
+  * <p>Tag immediately before the text.
+- *
+  * <p>No blank line before the tag.  // violation without filter
+  */
+ public class Test {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="JavadocParagraph"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="JavadocParagraphCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/context/expected.txt
@@ -1,0 +1,1 @@
+Test.java:7: <p> tag should be preceded with an empty line.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/newline/Test.java
@@ -1,0 +1,11 @@
+package TreeWalker.javadoc.JavadocParagraph;
+
+/**
+ * No tag (ok).
+ *
+ * <p>Tag immediately before the text.
+ * <p>No blank line before the tag.  // violation without filter
+ * <p>No blank line before the tag.  // violation without filter
+ */
+public class Test {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/newline/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index ecc14bd..1b9f309 100644
+--- a/Test.java
++++ b/Test.java
+@@ -5,6 +5,7 @@ package TreeWalker.javadoc.JavadocParagraph;
+  *
+  * <p>Tag immediately before the text.
+  * <p>No blank line before the tag.  // violation without filter
++ * <p>No blank line before the tag.  // violation without filter
+  */
+ public class Test {
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="JavadocParagraph"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:8: <p> tag should be preceded with an empty line.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/patchedline/Test.java
@@ -1,0 +1,11 @@
+package TreeWalker.javadoc.JavadocParagraph;
+
+/**
+ * No tag (ok).
+ *
+ * <p>Tag immediately before the text.
+ * <p>No blank line before the tag.  // violation without filter
+ * <p>No blank line before the tag.  // violation without filter
+ */
+public class Test {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/patchedline/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index ecc14bd..1b9f309 100644
+--- a/Test.java
++++ b/Test.java
+@@ -5,6 +5,7 @@ package TreeWalker.javadoc.JavadocParagraph;
+  *
+  * <p>Tag immediately before the text.
+  * <p>No blank line before the tag.  // violation without filter
++ * <p>No blank line before the tag.  // violation without filter
+  */
+ public class Test {
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="JavadocParagraph"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocParagraph/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:8: <p> tag should be preceded with an empty line.


### PR DESCRIPTION
Issue #267: SuppressionPatchXpathFilter: JavadocParagraph's context strategy

common pattern: https://github.com/checkstyle/patch-filters/issues/8#issuecomment-669225569