### PR TITLE
Issue #270: SuppressionPatchXpathFilter: JavadocType's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -144,6 +144,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testJavadocType() throws Exception {
+        testByConfig("JavadocType/newline/defaultContextConfig.xml");
+        testByConfig("JavadocType/patchedline/defaultContextConfig.xml");
+        testByConfig("JavadocType/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testFinalClass() throws Exception {
         testByConfig("FinalClass/newline/defaultContextConfig.xml");
         testByConfig("FinalClass/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/context/Test.java
@@ -1,0 +1,7 @@
+package TreeWalker.javadoc.JavadocType;
+
+/**
+ *
+ */
+public class Test {  // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/context/defaultContext.patch
@@ -1,0 +1,13 @@
+diff --git a/Test.java b/Test.java
+index 2ec3080..32405c4 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,7 +1,7 @@
+ package TreeWalker.javadoc.JavadocType;
+ 
+ /**
+- * @author test
++ *
+  */
+ public class Test {  // violation without filter
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/context/defaultContextConfig.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="JavadocType">
+            <property name="scope" value="public"/>
+            <property name="authorFormat" value="\S"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="JavadocTypeCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/context/expected.txt
@@ -1,0 +1,1 @@
+Test.java:6:1: Type Javadoc comment is missing @author tag.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/newline/Test.java
@@ -1,0 +1,7 @@
+package TreeWalker.javadoc.JavadocType;
+
+/**
+ *
+ */
+public class Test {  // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/newline/defaultContext.patch
@@ -1,0 +1,13 @@
+diff --git a/Test.java b/Test.java
+new file mode 100644
+index 0000000..82674fa
+--- /dev/null
++++ b/Test.java
+@@ -0,0 +1,7 @@
++package TreeWalker.javadoc.JavadocType;
++
++/**
++ *
++ */
++public class Test {  // violation without filter
++}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/newline/defaultContextConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="JavadocType">
+            <property name="scope" value="public"/>
+            <property name="authorFormat" value="\S"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:6:1: Type Javadoc comment is missing @author tag.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/patchedline/Test.java
@@ -1,0 +1,7 @@
+package TreeWalker.javadoc.JavadocType;
+
+/**
+ *
+ */
+public class Test {  // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/patchedline/defaultContext.patch
@@ -1,0 +1,13 @@
+diff --git a/Test.java b/Test.java
+new file mode 100644
+index 0000000..82674fa
+--- /dev/null
++++ b/Test.java
+@@ -0,0 +1,7 @@
++package TreeWalker.javadoc.JavadocType;
++
++/**
++ *
++ */
++public class Test {  // violation without filter
++}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/patchedline/defaultContextConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="JavadocType">
+            <property name="scope" value="public"/>
+            <property name="authorFormat" value="\S"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/JavadocType/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:6:1: Type Javadoc comment is missing @author tag.


### PR DESCRIPTION
Issue #270: SuppressionPatchXpathFilter: JavadocType's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-669225569