### PR TITLE
Issue #278: SuppressionPatchXpathFilter: MissingJavadocType's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -130,6 +130,13 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testMissingJavadocType() throws Exception {
+        testByConfig("MissingJavadocType/newline/defaultContextConfig.xml");
+        testByConfig("MissingJavadocType/patchedline/defaultContextConfig.xml");
+        testByConfig("MissingJavadocType/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testInnerTypeLast() throws Exception {
         testByConfig("InnerTypeLast/newline/defaultContextConfig.xml");
         testByConfig("InnerTypeLast/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/context/Test.java
@@ -1,0 +1,4 @@
+package TreeWalker.javadoc.MissingJavadocType;
+
+public class Test {  // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/context/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 3a056ca..8702d4a 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,7 +1,4 @@
+ package TreeWalker.javadoc.MissingJavadocType;
+ 
+-/**
+- * test
+- */
+ public class Test {  // violation without filter
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/context/defaultContextConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingJavadocType">
+            <property name="scope" value="private"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="MissingJavadocTypeCheck" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/context/expected.txt
@@ -1,0 +1,1 @@
+Test.java:3: Missing a Javadoc comment.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/newline/Test.java
@@ -1,0 +1,7 @@
+package TreeWalker.javadoc.MissingJavadocType;
+
+public class Test {  // violation without filter
+}
+
+class Test1 {  // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/newline/defaultContext.patch
@@ -1,0 +1,11 @@
+diff --git a/Test.java b/Test.java
+index 8702d4a..ffc2a54 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,3 +2,6 @@ package TreeWalker.javadoc.MissingJavadocType;
+ 
+ public class Test {  // violation without filter
+ }
++
++class Test1 {  // violation without filter
++}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/newline/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingJavadocType">
+            <property name="scope" value="private"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:6: Missing a Javadoc comment.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/patchedline/Test.java
@@ -1,0 +1,7 @@
+package TreeWalker.javadoc.MissingJavadocType;
+
+public class Test {  // violation without filter
+}
+
+class Test1 {  // violation without filter
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/patchedline/defaultContext.patch
@@ -1,0 +1,11 @@
+diff --git a/Test.java b/Test.java
+index 8702d4a..ffc2a54 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,3 +2,6 @@ package TreeWalker.javadoc.MissingJavadocType;
+ 
+ public class Test {  // violation without filter
+ }
++
++class Test1 {  // violation without filter
++}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/patchedline/defaultContextConfig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingJavadocType">
+            <property name="scope" value="private"/>
+        </module>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/MissingJavadocType/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:6: Missing a Javadoc comment.


### PR DESCRIPTION
Issue #278: SuppressionPatchXpathFilter: MissingJavadocType's context strategy

common pattern https://github.com/checkstyle/patch-filters/issues/8#issuecomment-666272689