### PR TITLE
Issue #284: Add a new matching method to avoid suppress violations that are passed by SuppressionPatchXapthFilter

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchXpathFilterTest.java
@@ -52,6 +52,11 @@ public class SuppressionPatchXpathFilterTest extends AbstractPatchFilterEvaluati
     }
 
     @Test
+    public void testWithSuppressionPatchFilter() throws Exception {
+        testByConfig("WithSuppressionPatchFilter/contextSituation/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testVariableDeclarationUsageDistance() throws Exception {
         testByConfig("VariableDeclarationUsageDistance/newline/defaultContextConfig.xml");
         testByConfig("VariableDeclarationUsageDistance/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/WithSuppressionPatchFilter/contextSituation/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/WithSuppressionPatchFilter/contextSituation/Test.java
@@ -1,0 +1,20 @@
+package TreeWalker.FinalClass;
+
+public class Test {  // violation without filter
+    private Test() {}
+}
+
+class Test1 {  // violation without filter
+    private Test1() {}
+}
+
+class Test2 {  // violation without filter
+    private Test2() {
+        System.out.println();
+    }
+}
+
+class Test3 {  // violation without filter
+    private Test3() {}
+    private int a;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/WithSuppressionPatchFilter/contextSituation/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/WithSuppressionPatchFilter/contextSituation/defaultContext.patch
@@ -1,0 +1,28 @@
+diff --git a/Test.java b/Test.java
+index 2fc8329..d3dd3f2 100644
+--- a/Test.java
++++ b/Test.java
+@@ -1,18 +1,20 @@
+ package TreeWalker.FinalClass;
+ 
+-public final class Test {
++public class Test {  // violation without filter
+     private Test() {}
+ }
+ 
+ class Test1 {  // violation without filter
+     private Test1() {}
+-
+ }
+ 
+ class Test2 {  // violation without filter
+-    private Test2() {}
++    private Test2() {
++        System.out.println();
++    }
+ }
+ 
+ class Test3 {  // violation without filter
+     private Test3() {}
++    private int a;
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/WithSuppressionPatchFilter/contextSituation/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/WithSuppressionPatchFilter/contextSituation/defaultContextConfig.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="FinalClass"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchXpathFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="supportContextStrategyChecks" value="FinalClassCheck" />
+        </module>
+    </module>
+
+    <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
+        <property name="file" value="${tp}/defaultContext.patch" />
+        <property name="strategy" value="context" />
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/WithSuppressionPatchFilter/contextSituation/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchxpathfilter/WithSuppressionPatchFilter/contextSituation/expected.txt
@@ -1,0 +1,4 @@
+Test.java:11:1: Class Test2 should be declared as final.
+Test.java:17:1: Class Test3 should be declared as final.
+Test.java:3:1: Class Test should be declared as final.
+Test.java:7:1: Class Test1 should be declared as final.


### PR DESCRIPTION
Issue #284: Add a new matching method to avoid suppress violations that are passed by SuppressionPatchXapthFilter.

I try the solution mentioned in https://github.com/checkstyle/checkstyle/issues/8602#issuecomment-670525645, but one problem is that how do we deal with ClassNotFoundException that introduced by `Class.forName(sourceName);`, now I catch it and config suppression `<suppress checks="ReturnCount" files="SuppressionPatchFilterElement\.java"/>`.
```java
catch (ClassNotFoundException ex) {
            System.out.println("an error occurred when load patch file" + ex);
            return false;
        }
```