### PR TITLE
Issue 295: Context strategy Checker patch filter shouldn't contain hardcoded checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
@@ -67,7 +67,6 @@ public class SuppressionPatchFilterElement implements Filter {
         return isFileNameMatching(event)
                 && (isTreeWalkerChecksMatching(event)
                 || isNeverSuppressCheck(event)
-                || isContextStrategyCheck(event)
                 || isLineMatching(event));
     }
 
@@ -122,25 +121,6 @@ public class SuppressionPatchFilterElement implements Filter {
                     break;
                 }
             }
-        }
-        return result;
-    }
-
-    /**
-     * Is matching by context strategy check.
-     *
-     * @param event event
-     * @return true if it is matching
-     */
-    private boolean isContextStrategyCheck(AuditEvent event) {
-        boolean result = false;
-        final String checkShortName = getCheckShortName(event);
-        if ("RegexpOnFilenameCheck".equals(checkShortName)
-                || "RegexpHeaderCheck".equals(checkShortName)
-                || "FileLengthCheck".equals(checkShortName)
-                || "NewlineAtEndOfFileCheck".equals(checkShortName)
-                || "HeaderCheck".equals(checkShortName)) {
-            result = true;
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterTest.java
@@ -210,6 +210,12 @@ public class SuppressionPatchFilterTest extends AbstractPatchFilterEvaluationTes
     }
 
     @Test
+    public void testHeader() throws Exception {
+        testByConfig("Header/newline/defaultContextConfig.xml");
+        testByConfig("Header/patchedline/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testTranslation() throws Exception {
         testByConfig("Translation/caseOne/newline/defaultContextConfig.xml");
         testByConfig("Translation/caseOne/patchedline/defaultContextConfig.xml");
@@ -219,11 +225,5 @@ public class SuppressionPatchFilterTest extends AbstractPatchFilterEvaluationTes
 
         testByConfig("Translation/caseThree/newline/defaultContextConfig.xml");
         testByConfig("Translation/caseThree/patchedline/defaultContextConfig.xml");
-    }
-
-    @Test
-    public void testHeader() throws Exception {
-        testByConfig("Header/newline/defaultContextConfig.xml");
-        testByConfig("Header/patchedline/defaultContextConfig.xml");
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/defaultContextConfig.xml
@@ -9,5 +9,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="newline" />
+    <property name="neverSuppressedChecks" value="FileLength" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/newline/zeroContextConfig.xml
@@ -9,5 +9,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/zeroContext.patch" />
     <property name="strategy" value="newline" />
+    <property name="neverSuppressedChecks" value="FileLength" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/defaultContextConfig.xml
@@ -9,5 +9,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="patchedline" />
+    <property name="neverSuppressedChecks" value="FileLength" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/FileLength/patchedline/zeroContextConfig.xml
@@ -9,5 +9,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/zeroContext.patch" />
     <property name="strategy" value="patchedline" />
+    <property name="neverSuppressedChecks" value="FileLength" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Header/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Header/newline/defaultContextConfig.xml
@@ -11,5 +11,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="newline" />
+    <property name="neverSuppressedChecks" value="Header" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Header/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/Header/patchedline/defaultContextConfig.xml
@@ -11,5 +11,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="patchedline" />
+    <property name="neverSuppressedChecks" value="Header" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/defaultContextConfig.xml
@@ -7,5 +7,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="newline" />
+    <property name="neverSuppressedChecks" value="NewlineAtEndOfFile" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/newline/zeroContextConfig.xml
@@ -7,5 +7,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/zeroContext.patch" />
     <property name="strategy" value="newline" />
+    <property name="neverSuppressedChecks" value="NewlineAtEndOfFile" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/defaultContextConfig.xml
@@ -7,5 +7,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="patchedline" />
+    <property name="neverSuppressedChecks" value="NewlineAtEndOfFile" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/NewlineAtEndOfFile/patchedline/zeroContextConfig.xml
@@ -7,5 +7,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/zeroContext.patch" />
     <property name="strategy" value="patchedline" />
+    <property name="neverSuppressedChecks" value="NewlineAtEndOfFile" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpHeader/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpHeader/newline/defaultContextConfig.xml
@@ -11,5 +11,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="newline" />
+    <property name="neverSuppressedChecks" value="RegexpHeader" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpHeader/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpHeader/patchedline/defaultContextConfig.xml
@@ -11,5 +11,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="patchedline" />
+    <property name="neverSuppressedChecks" value="RegexpHeader" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/defaultContextConfig.xml
@@ -9,5 +9,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="newline" />
+    <property name="neverSuppressedChecks" value="RegexpOnFilename" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/newline/zeroContextConfig.xml
@@ -9,5 +9,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/zeroContext.patch" />
     <property name="strategy" value="newline" />
+    <property name="neverSuppressedChecks" value="RegexpOnFilename" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/defaultContextConfig.xml
@@ -9,5 +9,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/defaultContext.patch" />
     <property name="strategy" value="patchedline" />
+    <property name="neverSuppressedChecks" value="RegexpOnFilename" />
   </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/zeroContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionpatchfilter/RegexpOnFilename/patchedline/zeroContextConfig.xml
@@ -9,5 +9,6 @@
   <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionPatchFilter">
     <property name="file" value="${tp}/zeroContext.patch" />
     <property name="strategy" value="patchedline" />
+    <property name="neverSuppressedChecks" value="RegexpOnFilename" />
   </module>
 </module>


### PR DESCRIPTION
Issue 295: Context strategy Checker patch filter shouldn't contain hardcoded checks