### PR TITLE
Issue #302: Implement checkNameForContextStrategyByTokenOrAncestorSet

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilter.java
@@ -83,6 +83,12 @@ public class SuppressionJavaPatchFilter extends AutomaticBean implements
     private Set<String> checkNamesForContextStrategyByTokenOrParentSet;
 
     /**
+     * Set has user defined Checks that need modify violation nodes
+     * to their ancestor abstract nodes to get their child nodes.
+     */
+    private Set<String> checkNamesForContextStrategyByTokenOrAncestorSet;
+
+    /**
      * Set has user defined Checks that support context strategy.
      */
     private Set<String> supportContextStrategyChecks;
@@ -121,14 +127,33 @@ public class SuppressionJavaPatchFilter extends AutomaticBean implements
      * Setter to set has user defined list of Checks need modify violation nodes
      * to their parent abstract nodes to get their child nodes.
      *
-     * @param checkNamesForContextStrategyByTokenOrParentSet string has user defined Checks to never
-     *                                                   suppress if files are touched, split
-     *                                                   by comma
+     * @param checkNamesForContextStrategyByTokenOrParentSet string which is  user defined Checks
+     *                                                         that need modify violation nodes
+     *                                                         to their parent abstract nodes
+     *                                                         to get their child nodes,
+     *                                                         split by comma
      */
     public void setCheckNamesForContextStrategyByTokenOrParentSet(
             String checkNamesForContextStrategyByTokenOrParentSet) {
         final String[] checksArray = checkNamesForContextStrategyByTokenOrParentSet.split(COMMA);
         this.checkNamesForContextStrategyByTokenOrParentSet =
+                new HashSet<>(Arrays.asList(checksArray));
+    }
+
+    /**
+     * Setter to set has user defined list of Checks need modify violation nodes
+     * to their ancestor abstract nodes to get their child nodes.
+     *
+     * @param checkNamesForContextStrategyByTokenOrAncestorSet string which is  user defined Checks
+     *                                                         that need modify violation nodes
+     *                                                         to their ancestor abstract nodes
+     *                                                         to get their child nodes,
+     *                                                         split by comma
+     */
+    public void setCheckNamesForContextStrategyByTokenOrAncestorSet(
+            String checkNamesForContextStrategyByTokenOrAncestorSet) {
+        final String[] checksArray = checkNamesForContextStrategyByTokenOrAncestorSet.split(COMMA);
+        this.checkNamesForContextStrategyByTokenOrAncestorSet =
                 new HashSet<>(Arrays.asList(checksArray));
     }
 
@@ -210,6 +235,7 @@ public class SuppressionJavaPatchFilter extends AutomaticBean implements
                         new JavaPatchFilterElement(fileName, lineRangeList,
                                 strategy,
                                 checkNamesForContextStrategyByTokenOrParentSet,
+                                checkNamesForContextStrategyByTokenOrAncestorSet,
                                 supportContextStrategyChecks,
                                 neverSuppressedChecks);
                 filters.add(element);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/AvoidNestedBlocks/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/AvoidNestedBlocks/context/defaultContextConfig.xml
@@ -9,7 +9,7 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="context" />
-            <property name="neverSuppressedChecks" value="AvoidNestedBlocksCheck" />
+            <property name="checkNamesForContextStrategyByTokenOrAncestorSet" value="AvoidNestedBlocksCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/FinalLocalVariable/case1/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/FinalLocalVariable/case1/context/defaultContextConfig.xml
@@ -11,7 +11,8 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="context" />
-            <property name="neverSuppressedChecks" value="FinalLocalVariableCheck" />
+            <property name="checkNamesForContextStrategyByTokenOrAncestorSet"
+                      value="FinalLocalVariableCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/FinalLocalVariable/case1/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/FinalLocalVariable/case1/context/expected.txt
@@ -1,4 +1,3 @@
 Test.java:4:24: Variable 'x' should be declared final.
 Test.java:4:31: Variable 'y' should be declared final.
 Test.java:7:39: Variable 'args' should be declared final.
-Test.java:12:13: Variable 'result' should be declared final.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/FinalLocalVariable/case2/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/FinalLocalVariable/case2/context/defaultContextConfig.xml
@@ -11,7 +11,8 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="context" />
-            <property name="neverSuppressedChecks" value="FinalLocalVariableCheck" />
+            <property name="checkNamesForContextStrategyByTokenOrAncestorSet"
+                      value="FinalLocalVariableCheck" />
         </module>
     </module>
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/FinalLocalVariable/case2/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/FinalLocalVariable/case2/context/expected.txt
@@ -1,4 +1,2 @@
 Test.java:8:39: Variable 'args' should be declared final.
 Test.java:14:13: Variable 'myconst' should be declared final.
-Test.java:12:13: Variable 'result' should be declared final.
-Test.java:4:31: Variable 'y' should be declared final.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/RightCurly/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/RightCurly/context/defaultContextConfig.xml
@@ -9,7 +9,7 @@
         <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
             <property name="file" value="${tp}/defaultContext.patch" />
             <property name="strategy" value="context" />
-            <property name="neverSuppressedChecks" value="RightCurlyCheck" />
+            <property name="checkNamesForContextStrategyByTokenOrAncestorSet" value="RightCurlyCheck" />
         </module>
     </module>
 </module>


### PR DESCRIPTION
Issue #302: Implement checkNameForContextStrategyByTokenOrAncestorSet

this PR update `checkNameForContextStrategyByTokenOrParentSet` to `checkNameForContextStrategyByTokenOrAncestorSet`. This update does not affect original checks listed in https://github.com/checkstyle/patch-filters/issues/302#issuecomment-674096024 that using `ParentSet`, and will make 14 checks not need to use `neverSuppressedChecks ` now, which will solve or relieve the problem is mentioned in issue #125