### PR TITLE
Issue #131: SuppressionPatchXpathFilter: MissingDeprecated's context strategy

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
@@ -229,6 +229,13 @@ public class SuppressionJavaPatchFilterTest extends AbstractPatchFilterEvaluatio
     }
 
     @Test
+    public void testMissingDeprecated() throws Exception {
+        testByConfig("MissingDeprecated/newline/defaultContextConfig.xml");
+        testByConfig("MissingDeprecated/patchedline/defaultContextConfig.xml");
+        testByConfig("MissingDeprecated/context/defaultContextConfig.xml");
+    }
+
+    @Test
     public void testReturnCount() throws Exception {
         testByConfig("ReturnCount/newline/defaultContextConfig.xml");
         testByConfig("ReturnCount/patchedline/defaultContextConfig.xml");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/context/Test.java
@@ -1,0 +1,10 @@
+package TreeWalker.Annotation.MissingDeprecated;
+
+public class Test {
+    @Deprecated
+    public static final int MY_CONST = 123456;
+
+    /** This javadoc is missing deprecated tag. */
+    @Deprecated  // violation without filter
+    public static final int COUNTER = 10;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/context/defaultContext.patch
@@ -1,0 +1,12 @@
+diff --git a/Test.java b/Test.java
+index 1db8efd..bc0daf9 100644
+--- a/Test.java
++++ b/Test.java
+@@ -4,6 +4,7 @@ public class Test {
+     @Deprecated
+     public static final int MY_CONST = 123456;
+ 
++    /** This javadoc is missing deprecated tag. */
+     @Deprecated  // violation without filter
+     public static final int COUNTER = 10;
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/context/defaultContextConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingDeprecated"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="neverSuppressedChecks" value="MissingDeprecated" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/context/expected.txt
@@ -1,0 +1,1 @@
+Test.java:8: Must include both @java.lang.Deprecated annotation and @deprecated Javadoc tag with description.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/newline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/newline/Test.java
@@ -1,0 +1,14 @@
+package TreeWalker.Annotation.MissingDeprecated;
+
+public class Test {
+    @Deprecated
+    public static final int MY_CONST = 123456;
+
+    /** This javadoc is missing deprecated tag. */
+    @Deprecated  // violation without filter
+    public static final int COUNTER = 10;
+
+    /** This javadoc is missing deprecated tag. */
+    @Deprecated  // violation without filter
+    public static final int COUNTER2 = 10;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/newline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/newline/defaultContext.patch
@@ -1,0 +1,13 @@
+diff --git a/Test.java b/Test.java
+index bc0daf9..12d7b51 100644
+--- a/Test.java
++++ b/Test.java
+@@ -7,4 +7,8 @@ public class Test {
+     /** This javadoc is missing deprecated tag. */
+     @Deprecated  // violation without filter
+     public static final int COUNTER = 10;
++
++    /** This javadoc is missing deprecated tag. */
++    @Deprecated  // violation without filter
++    public static final int COUNTER2 = 10;
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/newline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/newline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingDeprecated"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="newline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/newline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:12: Must include both @java.lang.Deprecated annotation and @deprecated Javadoc tag with description.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/patchedline/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/patchedline/Test.java
@@ -1,0 +1,14 @@
+package TreeWalker.Annotation.MissingDeprecated;
+
+public class Test {
+    @Deprecated
+    public static final int MY_CONST = 123456;
+
+    /** This javadoc is missing deprecated tag. */
+    @Deprecated  // violation without filter
+    public static final int COUNTER = 10;
+
+    /** This javadoc is missing deprecated tag. */
+    @Deprecated  // violation without filter
+    public static final int COUNTER2 = 10;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/patchedline/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/patchedline/defaultContext.patch
@@ -1,0 +1,13 @@
+diff --git a/Test.java b/Test.java
+index bc0daf9..12d7b51 100644
+--- a/Test.java
++++ b/Test.java
+@@ -7,4 +7,8 @@ public class Test {
+     /** This javadoc is missing deprecated tag. */
+     @Deprecated  // violation without filter
+     public static final int COUNTER = 10;
++
++    /** This javadoc is missing deprecated tag. */
++    @Deprecated  // violation without filter
++    public static final int COUNTER2 = 10;
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/patchedline/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/patchedline/defaultContextConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MissingDeprecated"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="patchedline" />
+        </module>
+    </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/MissingDeprecated/patchedline/expected.txt
@@ -1,0 +1,1 @@
+Test.java:12: Must include both @java.lang.Deprecated annotation and @deprecated Javadoc tag with description.


### PR DESCRIPTION
Issue #131: SuppressionPatchXpathFilter: MissingDeprecated's context strategy 

As mentioned in https://github.com/checkstyle/patch-filters/issues/131#issuecomment-662466401, MissingDeprecated still does not support return log AST, so its context strategy should use `neverSuppressedChecks`