### PR TITLE
config: upgrade tests to jupiter and drop junit 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,14 @@
       <artifactId>org.eclipse.jgit</artifactId>
       <version>6.3.0.202209071007-r</version>
     </dependency>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
@@ -68,12 +76,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileTest.java
+++ b/src/test/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileTest.java
@@ -19,7 +19,7 @@
 
 package com.github.checkstyle.generatepatchfile;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeneratePatchFileTest {
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/AbstractPatchFilterEvaluationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/AbstractPatchFilterEvaluationTest.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -103,11 +103,10 @@ abstract class AbstractPatchFilterEvaluationTest extends AbstractModuleTestSuppo
             for (int index = 0; index < expected.size(); index++) {
                 final String seperate = "/";
                 final String expectedResult = path + seperate + expected.get(index);
-                assertEquals("error message " + index + ". Expected file: "
-                        + expectedFilePath, expectedResult, actuals.get(index));
+                assertEquals(expectedResult, actuals.get(index),
+                        "error message " + index + ". Expected file: " + expectedFilePath);
             }
-            assertEquals("unexpected output: " + lnr.readLine(),
-                    expected.size(), errorCounter);
+            assertEquals(expected.size(), errorCounter, "unexpected output: " + lnr.readLine());
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterTest.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SuppressionPatchFilterTest extends AbstractPatchFilterEvaluationTest {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffOnOpenSourceTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffOnOpenSourceTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffWithContextSizeDefaultTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffWithContextSizeDefaultTest.java
@@ -19,8 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.jgit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.List;
@@ -29,7 +29,7 @@ import org.eclipse.jgit.diff.Edit;
 import org.eclipse.jgit.diff.EditList;
 import org.eclipse.jgit.patch.FileHeader;
 import org.eclipse.jgit.patch.Patch;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GitDiffWithContextSizeDefaultTest extends AbstractJgitPatchParserEvaluationTest {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffWithContextSizeZeroTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffWithContextSizeZeroTest.java
@@ -19,8 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.jgit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.List;
@@ -29,7 +29,7 @@ import org.eclipse.jgit.diff.Edit;
 import org.eclipse.jgit.diff.EditList;
 import org.eclipse.jgit.patch.FileHeader;
 import org.eclipse.jgit.patch.Patch;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GitDiffWithContextSizeZeroTest extends AbstractJgitPatchParserEvaluationTest {
 


### PR DESCRIPTION
Upgrading as I couldn't run tests in Eclipse on the project without downgrading JUnit runner. My tests are still failing, so I can't validate this change locally.