### PR TITLE
infra: adds cache and removes transfers from github run

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,10 +8,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
+    - name: Setup local maven cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: maven-cache-${{ hashFiles('**/pom.xml') }}
+
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 11
+
     - name: Build with Maven
-      run: mvn install
+      run: mvn -e --no-transfer-progress install


### PR DESCRIPTION
https://github.com/checkstyle/patch-filters/actions/runs/3446645759/jobs/5751807354#step:4:9
Logs are spammed with constant download messages. This is to trim back on that so the logs are easier to read.