### PR TITLE
Issue #113: fixes for windows support in GitDiffs

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/jgit/AbstractJgitPatchParserEvaluationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/jgit/AbstractJgitPatchParserEvaluationTest.java
@@ -25,13 +25,15 @@ import java.io.InputStream;
 
 import org.eclipse.jgit.patch.Patch;
 
+import com.puppycrawl.tools.checkstyle.filters.CrFilterInputStream;
+
 public abstract class AbstractJgitPatchParserEvaluationTest {
 
     protected abstract String getPatchPath(String patchName);
 
     protected static Patch loadPatch(String patchPath) throws IOException {
         final Patch patch = new Patch();
-        try (InputStream is = new FileInputStream(patchPath)) {
+        try (InputStream is = new CrFilterInputStream(new FileInputStream(patchPath))) {
             patch.parse(is);
         }
         return patch;


### PR DESCRIPTION
Issue #113

** This is the SECOND to last PR hopefully. ** This fixes support in the 3 GitDiff tests.

`SuppressionJavaPatchFilterTest` is the only thing that remains with 2 failing tests.