### PR TITLE
allows to catch jgit exceptions in suppression filters

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilter.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
@@ -241,8 +240,11 @@ public class SuppressionJavaPatchFilter extends AutomaticBean implements
                 filters.add(element);
             }
         }
-        catch (IOException ex) {
-            throw new CheckstyleException("an error occurred when load patch file", ex);
+        // -@cs[IllegalCatch] There is no other way to deliver filename that was under
+        // processing when a jgit exception occurs.
+        catch (Exception exception) {
+            throw new CheckstyleException("an error occurred when loading patch file "
+                    + file, exception);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilter.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
@@ -168,8 +167,11 @@ public class SuppressionPatchFilter extends AutomaticBean
                 filters.addFilter(element);
             }
         }
-        catch (IOException ex) {
-            throw new CheckstyleException("an error occurred when load patch file", ex);
+        // -@cs[IllegalCatch] There is no other way to deliver filename that was under
+        // processing when a jgit exception occurs.
+        catch (Exception exception) {
+            throw new CheckstyleException("an error occurred when loading patch file "
+                    + file, exception);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
@@ -60,7 +60,9 @@ public class SuppressionJavaPatchFilterTest extends AbstractPatchFilterEvaluatio
             assertEquals("cannot initialize module TreeWalker - "
                             + "cannot initialize module "
                             + "com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter "
-                            + "- an error occurred when load patch file", ex.getMessage(),
+                            + "- an error occurred when loading patch file "
+                            + getPatchFileLocation() + "Optional/false//defaultContext.patch",
+                            ex.getMessage(),
                     "Invalid error message");
         }
     }


### PR DESCRIPTION
Similar to https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java#L298-L300

When JGit fails, it doesn't throw an IOException (atleast not all the time). I was getting custom exceptions that extend IllegalArguments like when the `\r` was still in the file. When it happened it skipped displaying our chain of the exception. This will ensure we get our message in.