### PR TITLE
infra: enable more platform runs in CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,10 @@ on:
     branches: [ master ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,11 +1,11 @@
-name: Java CI with Maven
+name: CI
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
 jobs:
-  build:
+  install:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
Adding more platforms in the CI.

The combination of https://github.com/checkstyle/patch-filters/pull/361 and this completes https://github.com/checkstyle/patch-filters/issues/113 .