### PR TITLE
Issue #382: Fix RightCurly Violation

### DIFF
--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFile.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFile.java
@@ -141,8 +141,7 @@ public class GeneratePatchFile {
             this.repository = new FileRepositoryBuilder().setGitDir(gitDir)
                     .readEnvironment().findGitDir().build();
             git = new Git(repository);
-        }
-        catch (IOException exception) {
+        } catch (IOException exception) {
             exception.printStackTrace();
         }
         diffReportDirName = new File(".").getAbsoluteFile().getParent() + "/DiffReport";
@@ -261,14 +260,11 @@ public class GeneratePatchFile {
     private void generateDiffPatchWithGitCommand(int headNum, String patchFormat) throws Exception {
         if ("show".equals(patchFormat)) {
             runShellCommand("git show > show.patch");
-        }
-        else if ("diff".equals(patchFormat)) {
+        } else if ("diff".equals(patchFormat)) {
             runShellCommand("git diff HEAD~1 HEAD > show.patch");
-        }
-        else if ("format".equals(patchFormat)) {
+        } else if ("format".equals(patchFormat)) {
             runShellCommand("git format-patch -1");
-        }
-        else {
+        } else {
             throw new IllegalArgumentException("patchFormat should be 'show', 'diff' or 'format'");
         }
         final File repoDir = new File(repoPath);
@@ -405,8 +401,7 @@ public class GeneratePatchFile {
             }
             out.write("</h2>\n</body></html>");
 
-        }
-        catch (IOException exception) {
+        } catch (IOException exception) {
             exception.printStackTrace();
         }
     }

--- a/src/main/java/com/github/checkstyle/generatepatchfile/Utils.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/Utils.java
@@ -53,8 +53,7 @@ public final class Utils {
                 final File destFile = new File(dest, file);
                 copyDir(srcFile, destFile);
             }
-        }
-        else {
+        } else {
             final InputStream inputStream = new FileInputStream(src);
             final OutputStream outputStream = new FileOutputStream(dest);
             final int size = 1024;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/JavaPatchFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/JavaPatchFilterElement.java
@@ -311,8 +311,7 @@ public final class JavaPatchFilterElement implements TreeWalkerFilter {
                     eventAst = eventAst.getParent();
                 }
             }
-        }
-        else if (containsShortName(checkNamesForContextStrategyByTokenOrParentSet, event)) {
+        } else if (containsShortName(checkNamesForContextStrategyByTokenOrParentSet, event)) {
             if (eventAst != null) {
                 eventAst = eventAst.getParent();
             }
@@ -408,8 +407,7 @@ public final class JavaPatchFilterElement implements TreeWalkerFilter {
             final int lineNo = ast.getLineNo();
             if (lineNo < childAstLineNoMap.get(MIN)) {
                 childAstLineNoMap.put(MIN, lineNo);
-            }
-            else if (lineNo > childAstLineNoMap.get(MAX)) {
+            } else if (lineNo > childAstLineNoMap.get(MAX)) {
                 childAstLineNoMap.put(MAX, lineNo);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/LoadPatchFileUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/LoadPatchFileUtils.java
@@ -87,15 +87,13 @@ public class LoadPatchFileUtils {
             if (lineRange != null) {
                 lineRangeList.add(lineRange);
             }
-        }
-        else if (Strategy.PATCHEDLINE == strategy) {
+        } else if (Strategy.PATCHEDLINE == strategy) {
             final List<Integer> lineRange = getLineRange(edit,
                     Arrays.asList(Edit.Type.INSERT, Edit.Type.REPLACE));
             if (lineRange != null) {
                 lineRangeList.add(lineRange);
             }
-        }
-        else {
+        } else {
             final List<Integer> lineRange = getLineRange(edit,
                     Arrays.asList(Edit.Type.INSERT, Edit.Type.REPLACE,
                             Edit.Type.DELETE));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilter.java
@@ -215,12 +215,10 @@ public final class SuppressionJavaPatchFilter extends AutomaticBean implements
             if (optional) {
                 if (FilterUtil.isFileExists(file)) {
                     loadPatchFile();
-                }
-                else {
+                } else {
                     filters = new HashSet<>();
                 }
-            }
-            else {
+            } else {
                 loadPatchFile();
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilter.java
@@ -142,12 +142,10 @@ public final class SuppressionPatchFilter extends AutomaticBean
             if (optional) {
                 if (FilterUtil.isFileExists(file)) {
                     loadPatchFile();
-                }
-                else {
+                } else {
                     filters = new PatchFilterSet();
                 }
-            }
-            else {
+            } else {
                 loadPatchFile();
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
@@ -109,8 +109,7 @@ public final class SuppressionPatchFilterElement implements Filter {
                 result = true;
             }
             return result;
-        }
-        catch (ClassNotFoundException exception) {
+        } catch (ClassNotFoundException exception) {
             throw new IllegalStateException("Class " + sourceName + " not found", exception);
         }
     }


### PR DESCRIPTION
Issue : #382
Fix Right Curly violations.
Two Violations of Right curly has not been solved as there were `single-line comment` before catch.