### PR TITLE
Fix : Added missing context directory for MagicNumber

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilterTest.java
@@ -237,6 +237,7 @@ public class SuppressionJavaPatchFilterTest extends AbstractPatchFilterEvaluatio
     public void testMagicNumber() throws Exception {
         testByConfig("coding/MagicNumber/newline/defaultContextConfig.xml");
         testByConfig("coding/MagicNumber/patchedline/defaultContextConfig.xml");
+        testByConfig("coding/MagicNumber/context/defaultContextConfig.xml");
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/coding/MagicNumber/context/Test.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/coding/MagicNumber/context/Test.java
@@ -1,0 +1,9 @@
+package TreeWalker.MagicNumber;
+
+public class Test {
+    public void test() {
+        int a = 256
+                + 1;  // violation without filter
+    }
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/coding/MagicNumber/context/defaultContext.patch
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/coding/MagicNumber/context/defaultContext.patch
@@ -1,0 +1,13 @@
+diff --git a/Test.java b/Test.java
+index f76a7ce..a39d9e6 100644
+--- a/Test.java
++++ b/Test.java
+@@ -2,7 +2,7 @@ package TreeWalker.MagicNumber;
+
+ public class Test {
+     public void test() {
+         int a = 256
+-                + 2;
++                + 1;  // violation without filter
+     }
+ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/coding/MagicNumber/context/defaultContextConfig.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/coding/MagicNumber/context/defaultContextConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MagicNumber"/>
+
+        <module name="com.puppycrawl.tools.checkstyle.filters.SuppressionJavaPatchFilter">
+            <property name="file" value="${tp}/defaultContext.patch" />
+            <property name="strategy" value="context" />
+            <property name="checkNamesForContextStrategyByTokenOrParentSet"
+                value="MagicNumberCheck" />
+        </module>
+    </module>
+</module>
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/coding/MagicNumber/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/coding/MagicNumber/context/expected.txt
@@ -1,0 +1,1 @@
+Test.java:5:17: '256' is a magic number.


### PR DESCRIPTION
Added context directory for MagicNumber in  
`C:\Users\Jayanth Miriyala\patch filters\src\test\resources\com\puppycrawl\tools\checkstyle\filters\suppressionjavapatchfilter\coding\MagicNumber`
The context directory is  different from patchedLine. 