### PR TITLE
Issue #390: Validate CLI arguments and show usage in patch-file launchers

### DIFF
--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileLauncher.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileLauncher.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * GeneratePatchFileWithGitCommandLauncher.
+ * GeneratePatchFileLauncher.
  */
 public final class GeneratePatchFileLauncher {
 
@@ -40,6 +40,20 @@ public final class GeneratePatchFileLauncher {
      * @throws Exception exception
      */
     public static void main(String[] args) throws Exception {
+        final int requiredArgs = 7;
+        if (args.length < requiredArgs) {
+            System.err.println("Usage: GeneratePatchFileLauncher"
+                    + " <repoPath>"
+                    + " <checkstyleRepoPath>"
+                    + " <testerPath>"
+                    + " <checkstyleBranch>"
+                    + " <baseConfigFile>"
+                    + " <patchConfigFile>"
+                    + " <commitIdOrCount>");
+            System.err.println("  commitIdOrCount: a non-negative integer (number of recent"
+                    + " commits) or a comma-separated list of commit SHAs");
+            System.exit(1);
+        }
         final String repoPath = args[0];
         final String checkstyleRepoPath = args[1];
         final String testerPath = args[2];

--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileWithGitCommandLauncher.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileWithGitCommandLauncher.java
@@ -37,6 +37,21 @@ public final class GeneratePatchFileWithGitCommandLauncher {
      * @throws Exception exception
      */
     public static void main(String[] args) throws Exception {
+        final int requiredArgs = 8;
+        if (args.length < requiredArgs) {
+            System.err.println("Usage: GeneratePatchFileWithGitCommandLauncher"
+                    + " <repoPath>"
+                    + " <checkstyleRepoPath>"
+                    + " <testerPath>"
+                    + " <checkstyleBranch>"
+                    + " <baseConfigFile>"
+                    + " <patchConfigFile>"
+                    + " <commitCount>"
+                    + " <gitCommand>");
+            System.err.println("  commitCount: a non-negative integer");
+            System.err.println("  gitCommand:  git command string to generate the patch");
+            System.exit(1);
+        }
         final String repoPath = args[0];
         final String checkstyleRepoPath = args[1];
         final String testerPath = args[2];


### PR DESCRIPTION
Issue #390

Issue was - Both launchers crashed with a raw `ArrayIndexOutOfBoundsException` when called with missing or insufficient arguments. Users had no idea what arguments were expected.

to fix it i've added an argument count check at the top of `main()` in both launchers. If the count is less than required, a usage message is printed to stderr and an `IllegalArgumentException` is thrown with a clear message.

- `GeneratePatchFileLauncher` — requires 7 arguments
- `GeneratePatchFileWithGitCommandLauncher` — requires 8 arguments


## Reproduction logs (before fix) / (after fix)
**1. GeneratePatchFileWithGitCommandLauncher — no arguments**

Command:
```
mvn -q -DskipTests exec:java -Dexec.mainClass="com.github.checkstyle.generatepatchfile.GeneratePatchFileWithGitCommandLauncher" -Dexec.args=""
```
Output:
(before fix)
```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.6.3:java (default-cli) on project patch-filters:
An exception occurred while executing the Java class.
Index 0 out of bounds for length 0 -> [Help 1]
```
(after fix)

```
$ mvn -q -DskipTests exec:java -Dexec.mainClass="com.github.checkstyle.generatepatchfile.GeneratePatchFileWithGitCommandLauncher" -Dexec.args=""
Usage: GeneratePatchFileWithGitCommandLauncher <repoPath> <checkstyleRepoPath> <testerPath> <checkstyleBranch> <baseConfigFile> <patchConfigFile> <commitCount> <gitCommand>
  commitCount: a non-negative integer
  gitCommand:  git command string to generate the patch
[ERROR] ... Expected at least 8 arguments, but got: 0
```
**2. GeneratePatchFileWithGitCommandLauncher — insufficient arguments**

Command:
```
mvn -q -DskipTests exec:java -Dexec.mainClass="com.github.checkstyle.generatepatchfile.GeneratePatchFileWithGitCommandLauncher" -Dexec.args="a b c d e f g"
```
Output:
(before fix)
```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.6.3:java (default-cli) on project patch-filters:
An exception occurred while executing the Java class.
For input string: "g" -> [Help 1]
```
(after fix)

```
$ mvn -q -DskipTests exec:java -Dexec.mainClass="com.github.checkstyle.generatepatchfile.GeneratePatchFileWithGitCommandLauncher" -Dexec.args="a b c d e f g"
Usage: GeneratePatchFileWithGitCommandLauncher <repoPath> <checkstyleRepoPath> <testerPath> <checkstyleBranch> <baseConfigFile> <patchConfigFile> <commitCount> <gitCommand>
  commitCount: a non-negative integer
  gitCommand:  git command string to generate the patch
[ERROR] ... Expected at least 8 arguments, but got: 7
```


**3. GeneratePatchFileLauncher — no arguments**

Command:
```
mvn -q -DskipTests exec:java -Dexec.mainClass="com.github.checkstyle.generatepatchfile.GeneratePatchFileLauncher" -Dexec.args=""
```
Output:
(before fix)
```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.6.3:java (default-cli) on project patch-filters:
An exception occurred while executing the Java class.
Index 0 out of bounds for length 0 -> [Help 1]
```

(after fix)

```
$ mvn -q -DskipTests exec:java -Dexec.mainClass="com.github.checkstyle.generatepatchfile.GeneratePatchFileLauncher" -Dexec.args=""
Usage: GeneratePatchFileLauncher <repoPath> <checkstyleRepoPath> <testerPath> <checkstyleBranch> <baseConfigFile> <patchConfigFile> <commitIdOrCount>
  commitIdOrCount: a non-negative integer (number of recent commits) or a comma-separated list of commit SHAs
[ERROR] ... Expected at least 7 arguments, but got: 0
```
