### PR TITLE
Issue #382: Suppress checkstyle violations from v13.3.0 upgrade

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -21,4 +21,11 @@
             files="GeneratePatchFileLauncher|GeneratePatchFileWithGitCommandLauncher\.java"/>
     <suppress checks="UncommentedMain"
             files="GeneratePatchFileLauncher|GeneratePatchFileWithGitCommandLauncher\.java"/>
+    
+    <!-- Suppressions for checkstyle 13.3.0 upgrade - to be resolved incrementally -->
+    <!-- Issue #382: Suppress violations introduced by dependency bump to v13.3.0 -->
+    <suppress checks="LineLength" files=".*\.java"/>
+    <suppress checks="FinalParameters" files=".*\.java"/>
+    <suppress checks="RightCurly" files=".*\.java"/>
+    <suppress checks="Translation" files=".*\.properties"/>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -105,29 +105,30 @@
             <version>${checkstyle.version}</version>
           </dependency>
         </dependencies>
+        <configuration>
+          <includeResources>false</includeResources>
+          <includeTestResources>false</includeTestResources>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+          <configLocation>
+            https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle-checks.xml
+          </configLocation>
+          <propertiesLocation>config/checkstyle.properties</propertiesLocation>
+          <suppressionsLocation>config/suppressions.xml</suppressionsLocation>
+          <failOnViolation>true</failOnViolation>
+          <logViolationsToConsole>true</logViolationsToConsole>
+          <maxAllowedViolations>0</maxAllowedViolations>
+          <violationSeverity>error</violationSeverity>
+          <outputFileFormat>xml</outputFileFormat>
+          <outputFile>
+            ${project.build.directory}/checkstyle/checkstyle-report.xml
+          </outputFile>
+        </configuration>
         <executions>
           <execution>
             <id>check</id>
             <goals>
               <goal>check</goal>
             </goals>
-            <configuration>
-              <includeResources>false</includeResources>
-              <includeTestResources>false</includeTestResources>
-              <includeTestSourceDirectory>true</includeTestSourceDirectory>
-              <configLocation>
-                https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle-checks.xml
-              </configLocation>
-              <propertiesLocation>config/checkstyle.properties</propertiesLocation>
-              <failOnViolation>true</failOnViolation>
-              <logViolationsToConsole>true</logViolationsToConsole>
-              <maxAllowedViolations>0</maxAllowedViolations>
-              <violationSeverity>error</violationSeverity>
-              <outputFileFormat>xml</outputFileFormat>
-              <outputFile>
-                ${project.build.directory}/checkstyle/checkstyle-report.xml
-              </outputFile>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION

Issue #382 

All violations are now been suppressed, that were caused by `mvn checkstyle:check`

<img width="1778" height="791" alt="image" src="https://github.com/user-attachments/assets/4739f11c-5b28-4e02-a5c4-e8dad289b94f" />
