### PR TITLE
Issue #379: Upgrade junit.version from 5.9.1 to 5.12.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven.checkstyle.plugin.version>3.2.0</maven.checkstyle.plugin.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <junit.version>5.9.1</junit.version>
+    <junit.version>5.12.2</junit.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Issue #379 

Upgrade junit.version from 5.9.1 to 5.12.2 to gain bug fixes, improved stability, better Java compatibility, performance improvements, and enhanced testing features.

Benefits:
- Includes multiple bug fixes and stability improvements across JUnit 5.10–5.12 releases
- Improves compatibility with newer Java versions
- Provides performance optimizations in test execution
- Adds enhancements to parameterized tests and assertions
- Improves integration with modern build tools and IDEs
- Helps keep project dependencies up-to-date and maintainable