### PR TITLE
Issue #400: resolved MagicNumber suppressions

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -17,8 +17,6 @@
                      |TranslationCheckTest|LocalizedMessageTest|AbstractFileSetCheckTest|
                      |AbstractCheckTest|AutomaticBeanTest|GeneratePatchFile|
                      |AbstractPatchFilterEvaluationTest)\.java"/>
-    <suppress checks="MagicNumber"
-            files="GeneratePatchFileLauncher|GeneratePatchFileWithGitCommandLauncher\.java"/>
     <suppress checks="UncommentedMain"
             files="GeneratePatchFileLauncher|GeneratePatchFileWithGitCommandLauncher\.java"/>
     

--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileLauncher.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileLauncher.java
@@ -49,6 +49,16 @@ public final class GeneratePatchFileLauncher {
      */
     private static final int COMMIT_PARAM_ARG_INDEX = 6;
 
+    /**
+     * Required number of command line arguments.
+     */
+    private static final int REQUIRED_ARGS = 7;
+
+    /**
+     * Exit code for invalid arguments.
+     */
+    private static final int EXIT_CODE_INVALID_ARGS = 1;
+
     private GeneratePatchFileLauncher() {
 
     }
@@ -60,8 +70,7 @@ public final class GeneratePatchFileLauncher {
      * @throws Exception exception
      */
     public static void main(String[] args) throws Exception {
-        final int requiredArgs = 7;
-        if (args.length < requiredArgs) {
+        if (args.length < REQUIRED_ARGS) {
             System.err.println("Usage: GeneratePatchFileLauncher"
                     + " <repoPath>"
                     + " <checkstyleRepoPath>"
@@ -73,7 +82,7 @@ public final class GeneratePatchFileLauncher {
             System.err.println("  commitIdOrCount: a non-negative integer "
                     + "(number of recent commits) or a comma-separated list "
                     + "of commit SHAs");
-            System.exit(1);
+            System.exit(EXIT_CODE_INVALID_ARGS);
         }
         final String repoPath = args[0];
         final String checkstyleRepoPath = args[1];

--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileWithGitCommandLauncher.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileWithGitCommandLauncher.java
@@ -51,6 +51,16 @@ public final class GeneratePatchFileWithGitCommandLauncher {
      */
     private static final int GIT_COMMAND_ARG_INDEX = 7;
 
+    /**
+     * Required number of command line arguments.
+     */
+    private static final int REQUIRED_ARGS = 8;
+
+    /**
+     * Exit code for invalid arguments.
+     */
+    private static final int EXIT_CODE_INVALID_ARGS = 1;
+
     private GeneratePatchFileWithGitCommandLauncher() {
 
     }
@@ -62,8 +72,7 @@ public final class GeneratePatchFileWithGitCommandLauncher {
      * @throws Exception exception
      */
     public static void main(String[] args) throws Exception {
-        final int requiredArgs = 8;
-        if (args.length < requiredArgs) {
+        if (args.length < REQUIRED_ARGS) {
             System.err.println(
                     "Usage: GeneratePatchFileWithGitCommandLauncher"
                     + " <repoPath>"
@@ -77,7 +86,7 @@ public final class GeneratePatchFileWithGitCommandLauncher {
             System.err.println("  commitCount: a non-negative integer");
             System.err.println(
                     "  gitCommand:  git command string to generate the patch");
-            System.exit(1);
+            System.exit(EXIT_CODE_INVALID_ARGS);
         }
         final String repoPath = args[0];
         final String checkstyleRepoPath = args[1];


### PR DESCRIPTION
Issue #400
Removed ```MagicNumber``` suppressions from ```GeneratePatchFileLauncher``` and ```GeneratePatchFileWithGitCommandLauncher``` by replacing hardcoded values with named constants.

Suppression resolved is:
```
<suppress checks="MagicNumber"
            files="GeneratePatchFileLauncher|GeneratePatchFileWithGitCommandLauncher\.java"/>
```

All checks are passing now.