### PR TITLE
Issue #400: remove MissingJavadocMethod suppressions

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -5,11 +5,6 @@
     "https://checkstyle.org/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-    <!-- START of legacy code, all violations will be resolved during transition to main project -->
-    <suppress checks="MissingJavadocMethod" files="(GeneratePatchFile|GeneratePatchFileLauncher|
-                     |GeneratePatchFileWithGitCommandLauncher|JavaPatchFilterElement|LoadPatchFileUtils|
-                     |SuppressionJavaPatchFilter|SuppressionPatchFilter|SuppressionPatchFilterElement|
-                     |AbstractModuleTestSupport|AbstractPathTestSupport)\.java"/>
     <!-- END of legacy code -->
     <suppress checks="ClassDataAbstractionCoupling"
               files="(CheckerTest|AbstractModuleTestSupport|AbstractItModuleTestSupport|

--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFile.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFile.java
@@ -211,6 +211,12 @@ public class GeneratePatchFile {
         checkout(headSha);
     }
 
+    /**
+     * Gets the SHA of the current HEAD commit.
+     *
+     * @return the HEAD commit SHA
+     * @throws Exception if git command fails
+     */
     private String getHeadSha() throws Exception {
         runShellCommand("git rev-parse HEAD > HEAD_SHA");
         final Path path = new File(repoPath, "HEAD_SHA").toPath();
@@ -219,6 +225,12 @@ public class GeneratePatchFile {
         return headSha;
     }
 
+    /**
+     * Retrieves all commits from the repository.
+     *
+     * @return list of all commits
+     * @throws Exception if git operation fails
+     */
     private List<RevCommit> getAllCommits() throws Exception {
         final Iterable<RevCommit> commits =
                 git.log().add(repository.resolve("HEAD")).call();
@@ -232,6 +244,14 @@ public class GeneratePatchFile {
         return commitList;
     }
 
+    /**
+     * Generates a diff patch between two commits.
+     *
+     * @param commitOld the older commit
+     * @param commitNew the newer commit
+     * @throws Exception if patch generation fails
+     * @throws IOException if patch file cannot be moved
+     */
     private void generateTwoCommitDiffPatch(RevCommit commitOld,
                                             RevCommit commitNew)
             throws Exception {
@@ -273,6 +293,15 @@ public class GeneratePatchFile {
         }
     }
 
+    /**
+     * Generates a diff patch using git command.
+     *
+     * @param headNum the HEAD number
+     * @param patchFormat the patch format (show, diff, or format)
+     * @throws Exception if patch generation fails
+     * @throws IllegalArgumentException if patchFormat is invalid
+     * @throws IOException if patch file cannot be moved
+     */
     private void generateDiffPatchWithGitCommand(int headNum, String patchFormat)
             throws Exception {
         if ("show".equals(patchFormat)) {
@@ -316,6 +345,13 @@ public class GeneratePatchFile {
         }
     }
 
+    /**
+     * Runs a shell command in the repository directory.
+     *
+     * @param command the shell command to execute
+     * @throws Exception if command execution fails
+     * @throws IllegalStateException if command returns non-zero exit code
+     */
     private void runShellCommand(String command) throws Exception {
         final List<String> cmds = new ArrayList<>();
         cmds.add("sh");
@@ -333,6 +369,14 @@ public class GeneratePatchFile {
         }
     }
 
+    /**
+     * Creates a destination directory with the given subdirectory name.
+     *
+     * @param subDirName the subdirectory name
+     * @return the created directory file
+     * @throws Exception if directory already exists or creation fails
+     * @throws IOException if directory already exists
+     */
     private File createDestDirName(String subDirName) throws Exception {
         final File destDirFile = new File(diffReportDirName, subDirName);
         if (destDirFile.exists()) {
@@ -341,6 +385,12 @@ public class GeneratePatchFile {
         return destDirFile;
     }
 
+    /**
+     * Checks out HEAD~1 using git command.
+     *
+     * @throws Exception if checkout fails
+     * @throws IllegalStateException if git checkout command fails
+     */
     private void checkoutWithGitCommand() throws Exception {
         final Process process = new ProcessBuilder()
                 .directory(new File(repoPath))
@@ -354,10 +404,24 @@ public class GeneratePatchFile {
         }
     }
 
+    /**
+     * Checks out a specific commit.
+     *
+     * @param commitName the commit name or SHA to checkout
+     * @throws Exception if checkout fails
+     */
     private void checkout(String commitName) throws Exception {
         git.checkout().setName(commitName).call();
     }
 
+    /**
+     * Generates Checkstyle reports by running diff.groovy.
+     *
+     * @return the reports directory
+     * @throws InterruptedException if process is interrupted
+     * @throws IOException if report directory is invalid
+     * @throws IllegalStateException if diff.groovy execution fails
+     */
     private File generate()
             throws InterruptedException, IOException {
         final Process process = new ProcessBuilder()
@@ -386,11 +450,19 @@ public class GeneratePatchFile {
         return reportDir;
     }
 
+    /**
+     * Extracts the simple repository name from the repository path.
+     *
+     * @return the repository name
+     */
     private String getSimpleRepoName() {
         final String[] repoPaths = repoPath.split("/");
         return repoPaths[repoPaths.length - 1];
     }
 
+    /**
+     * Generates a summary index.html file for all generated reports.
+     */
     private void generateSummaryIndexHtml() {
         final File indexFile = new File(diffReportDirName, "index.html");
         try (FileWriter out = new FileWriter(indexFile)) {

--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileLauncher.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileLauncher.java
@@ -59,6 +59,9 @@ public final class GeneratePatchFileLauncher {
      */
     private static final int EXIT_CODE_INVALID_ARGS = 1;
 
+    /**
+     * Private constructor to prevent instantiation.
+     */
     private GeneratePatchFileLauncher() {
 
     }

--- a/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileWithGitCommandLauncher.java
+++ b/src/main/java/com/github/checkstyle/generatepatchfile/GeneratePatchFileWithGitCommandLauncher.java
@@ -61,6 +61,9 @@ public final class GeneratePatchFileWithGitCommandLauncher {
      */
     private static final int EXIT_CODE_INVALID_ARGS = 1;
 
+    /**
+     * Private constructor to prevent instantiation.
+     */
     private GeneratePatchFileWithGitCommandLauncher() {
 
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/JavaPatchFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/JavaPatchFilterElement.java
@@ -242,6 +242,12 @@ public final class JavaPatchFilterElement implements TreeWalkerFilter {
         return result;
     }
 
+    /**
+     * Checks if the current line matches any line range in the patch.
+     *
+     * @param currentLine the line number to check
+     * @return true if the line matches a range in the patch
+     */
     private boolean lineMatching(int currentLine) {
         boolean result = false;
         for (List<Integer> singleLineRangeList : lineRangeList) {
@@ -318,6 +324,12 @@ public final class JavaPatchFilterElement implements TreeWalkerFilter {
         return result;
     }
 
+    /**
+     * Gets the ancestor AST node for the event based on the check's context strategy.
+     *
+     * @param event the TreeWalkerAuditEvent
+     * @return the ancestor AST node, or null if not found
+     */
     private DetailAST getAncestorAst(TreeWalkerAuditEvent event) {
         DetailAST eventAst = getEventAst(event);
         if (containsShortName(
@@ -358,12 +370,24 @@ public final class JavaPatchFilterElement implements TreeWalkerFilter {
 
     }
 
+    /**
+     * Gets the check name from the event.
+     *
+     * @param event the TreeWalkerAuditEvent
+     * @return the check name
+     */
     private static String getCheckName(TreeWalkerAuditEvent event) {
         final String[] checkNames = event.violation()
                 .getSourceName().split("\\.");
         return checkNames[checkNames.length - 1];
     }
 
+    /**
+     * Gets the short check name (without "Check" suffix) from the event.
+     *
+     * @param event the TreeWalkerAuditEvent
+     * @return the short check name
+     */
     private static String getCheckShortName(TreeWalkerAuditEvent event) {
         return getCheckName(event).replaceAll("Check", "");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/LoadPatchFileUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/LoadPatchFileUtils.java
@@ -80,6 +80,12 @@ public class LoadPatchFileUtils {
         return lineRangeList;
     }
 
+    /**
+     * Adds a single line range to the list based on the edit type and strategy.
+     *
+     * @param lineRangeList the list to add the line range to
+     * @param edit the edit to process
+     */
     private void addSingleLineRange(List<List<Integer>> lineRangeList,
                                     Edit edit) {
         if (Strategy.NEWLINE == strategy) {
@@ -106,6 +112,13 @@ public class LoadPatchFileUtils {
         }
     }
 
+    /**
+     * Gets the line range from an edit if it matches the specified types.
+     *
+     * @param edit the edit to process
+     * @param typeList the list of edit types to match
+     * @return the line range as a list of two integers, or null if type doesn't match
+     */
     private static List<Integer> getLineRange(Edit edit,
                                               List<Edit.Type> typeList) {
         List<Integer> lineRange = null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionJavaPatchFilter.java
@@ -239,6 +239,11 @@ public final class SuppressionJavaPatchFilter extends AutomaticBean implements
         }
     }
 
+    /**
+     * Loads and parses the patch file to create filter elements.
+     *
+     * @throws CheckstyleException if patch file cannot be loaded or parsed
+     */
     private void loadPatchFile() throws CheckstyleException {
         try (InputStream is = new CrFilterInputStream(new FileInputStream(file))) {
             final Patch patch = new Patch();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilter.java
@@ -156,6 +156,11 @@ public final class SuppressionPatchFilter extends AutomaticBean
         }
     }
 
+    /**
+     * Loads and parses the patch file to create filter elements.
+     *
+     * @throws CheckstyleException if patch file cannot be loaded or parsed
+     */
     private void loadPatchFile() throws CheckstyleException {
         try (InputStream is = new CrFilterInputStream(new FileInputStream(file))) {
             final Patch patch = new Patch();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
@@ -156,6 +156,13 @@ public final class SuppressionPatchFilterElement implements Filter {
         return result;
     }
 
+    /**
+     * Checks if the check name set contains the event's check short name.
+     *
+     * @param checkNameSet the set of check names
+     * @param event the audit event
+     * @return true if the set contains the check short name
+     */
     private static boolean containsShortName(Set<String> checkNameSet,
                                       AuditEvent event) {
         final String checkShortName = getCheckShortName(event);
@@ -165,6 +172,12 @@ public final class SuppressionPatchFilterElement implements Filter {
 
     }
 
+    /**
+     * Gets the short check name from the event.
+     *
+     * @param event the audit event
+     * @return the short check name
+     */
     private static String getCheckShortName(AuditEvent event) {
         final String[] checkNames =
                 event.getViolation().getSourceName().split("\\.");


### PR DESCRIPTION
Issue #400

Added missing Javadoc comments to methods in launcher classes and removed the related `MissingJavadocMethod` suppressions from suppressions.xml.

Suppressions fixed:
```
<!-- START of legacy code, all violations will be resolved during transition to main project -->
    <suppress checks="MissingJavadocMethod" files="(GeneratePatchFile|GeneratePatchFileLauncher|
                     |GeneratePatchFileWithGitCommandLauncher|JavaPatchFilterElement|LoadPatchFileUtils|
                     |SuppressionJavaPatchFilter|SuppressionPatchFilter|SuppressionPatchFilterElement|
                     |AbstractModuleTestSupport|AbstractPathTestSupport)\.java"/>
```

All checks are passing now.