### PR TITLE
infra: add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: org.apache.maven.plugins:maven-release-plugin
+        versions:
+          - "> 2.1"
+    commit-message:
+      prefix: dependency
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: dependency


### PR DESCRIPTION
Added Dependabot configuration for Maven dependencies and GitHub Actions to keep dependencies up to date automatically.

As said by @romani in https://github.com/checkstyle/patch-filters/pull/399#issuecomment-4364918206

Reference i took from https://github.com/checkstyle/checkstyle/blob/master/.github/dependabot.yml