### PR TITLE
dependency: bump com.puppycrawl.tools:checkstyle from 13.3.0 to 13.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <checkstyle.version>13.3.0</checkstyle.version>
+    <checkstyle.version>13.4.2</checkstyle.version>
     <maven.checkstyle.plugin.version>3.6.0</maven.checkstyle.plugin.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionPatchFilterElement.java
@@ -126,9 +126,9 @@ public final class SuppressionPatchFilterElement implements Filter {
     private boolean isLineMatching(AuditEvent event) {
         boolean result = false;
         if (event.getViolation() != null) {
-            for (List<Integer> aLineRangeList : lineRangeList) {
-                final int startLine = aLineRangeList.get(0) + 1;
-                final int endLine = aLineRangeList.get(1) + 1;
+            for (List<Integer> lineRange : lineRangeList) {
+                final int startLine = lineRange.get(0) + 1;
+                final int endLine = lineRange.get(1) + 1;
                 final int currentLine = event.getLine();
                 result = currentLine >= startLine && currentLine < endLine;
                 if (result) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/ShortName/neverSuppressedChecks/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/ShortName/neverSuppressedChecks/expected.txt
@@ -1,1 +1,1 @@
-Test.java:4:1: Wrong order for 'java.awt.Dialog' import.
+Test.java:4:1: Wrong lexicographical order for 'java.awt.Dialog' import. Should be before 'java.awt.Frame'.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/import/ImportOrder/context/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/import/ImportOrder/context/expected.txt
@@ -1,1 +1,1 @@
-Test.java:4:1: Wrong order for 'java.awt.Dialog' import.
+Test.java:4:1: Wrong lexicographical order for 'java.awt.Dialog' import. Should be before 'java.awt.Frame'.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/import/ImportOrder/newline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/import/ImportOrder/newline/expected.txt
@@ -1,1 +1,1 @@
-Test.java:5:1: Wrong order for 'java.awt.DefaultFocusTraversalPolicy' import.
+Test.java:5:1: Wrong lexicographical order for 'java.awt.DefaultFocusTraversalPolicy' import. Should be before 'java.awt.Dialog'.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/import/ImportOrder/patchedline/expected.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionjavapatchfilter/import/ImportOrder/patchedline/expected.txt
@@ -1,1 +1,1 @@
-Test.java:5:1: Wrong order for 'java.awt.DefaultFocusTraversalPolicy' import.
+Test.java:5:1: Wrong lexicographical order for 'java.awt.DefaultFocusTraversalPolicy' import. Should be before 'java.awt.Dialog'.


### PR DESCRIPTION
Closes #410

As mentioned by @romani in https://github.com/checkstyle/patch-filters/pull/410#issuecomment-4415845483

Previous failure logs:
```
Error:  Failures: 
Error:    SuppressionJavaPatchFilterTest.testImportOrder:400->AbstractPatchFilterEvaluationTest.testByConfig:66->AbstractPatchFilterEvaluationTest.assertResults:106 error message 0. Expected file: D:\a\patch-filters\patch-filters\src\test\resources\com\puppycrawl\tools\checkstyle\filters\suppressionjavapatchfilter\import\ImportOrder\newline\expected.txt ==> expected: <D:\a\patch-filters\patch-filters\src\test\resources\com\puppycrawl\tools\checkstyle\filters\suppressionjavapatchfilter\import\ImportOrder\newline\Test.java:5:1: Wrong order for 'java.awt.DefaultFocusTraversalPolicy' import.> but was: <D:\a\patch-filters\patch-filters\src\test\resources\com\puppycrawl\tools\checkstyle\filters\suppressionjavapatchfilter\import\ImportOrder\newline\Test.java:5:1: Wrong lexicographical order for 'java.awt.DefaultFocusTraversalPolicy' import. Should be before 'java.awt.Dialog'.>
Error:    SuppressionJavaPatchFilterTest.testShortName:51->AbstractPatchFilterEvaluationTest.testByConfig:66->AbstractPatchFilterEvaluationTest.assertResults:106 error message 0. Expected file: D:\a\patch-filters\patch-filters\src\test\resources\com\puppycrawl\tools\checkstyle\filters\suppressionjavapatchfilter\ShortName\neverSuppressedChecks\expected.txt ==> expected: <D:\a\patch-filters\patch-filters\src\test\resources\com\puppycrawl\tools\checkstyle\filters\suppressionjavapatchfilter\ShortName\neverSuppressedChecks\Test.java:4:1: Wrong order for 'java.awt.Dialog' import.> but was: <D:\a\patch-filters\patch-filters\src\test\resources\com\puppycrawl\tools\checkstyle\filters\suppressionjavapatchfilter\ShortName\neverSuppressedChecks\Test.java:4:1: Wrong lexicographical order for 'java.awt.Dialog' import. Should be before 'java.awt.Frame'.>
[INFO] 
Error:  Tests run: 120, Failures: 2, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  31.756 s
[INFO] Finished at: 2026-05-10T16:29:21Z