### PR TITLE
infra: skip gitlint validation for Dependabot PRs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   gitlint:
+    if: ${{ !startsWith(github.event.pull_request.user.login, 'dependabot') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Investigated the gitlint failures on Dependabot dependency update PRs and found they were triggered by auto-generated commit messages exceeding the configured line-length limit. This change skips the gitlint job for Dependabot PRs while keeping the existing validation unchanged for all other contributors.

Fixes: https://github.com/checkstyle/patch-filters/pull/422#issuecomment-4618482330