### PR TITLE
dependency: bump com.puppycrawl.tools:checkstyle from 13.6.0 to 13.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <checkstyle.version>13.6.0</checkstyle.version>
+    <checkstyle.version>13.8.0</checkstyle.version>
     <maven.checkstyle.plugin.version>3.6.0</maven.checkstyle.plugin.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffOnOpenSourceTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/jgit/GitDiffOnOpenSourceTest.java
@@ -92,16 +92,16 @@ public class GitDiffOnOpenSourceTest extends AbstractModuleTestSupport {
     }
 
     private static SuppressionPatchFilter
+        createSuppressionPatchFilter(String fileName) throws Exception {
+        return createSuppressionPatchFilter(fileName, "patchedline");
+    }
+
+    private static SuppressionPatchFilter
         createSuppressionPatchFilter(String fileName, String strategy) throws Exception {
         final SuppressionPatchFilter suppressionPatchFilter = new SuppressionPatchFilter();
         suppressionPatchFilter.setFile(fileName);
         suppressionPatchFilter.setStrategy(strategy);
         suppressionPatchFilter.finishLocalSetup();
         return suppressionPatchFilter;
-    }
-
-    private static SuppressionPatchFilter
-        createSuppressionPatchFilter(String fileName) throws Exception {
-        return createSuppressionPatchFilter(fileName, "patchedline");
     }
 }


### PR DESCRIPTION
Bumps com.puppycrawl.tools:checkstyle from 13.6.0 to 13.8.0.

Includes the migration fix required by the new version: reorder the overloaded `createSuppressionPatchFilter` methods in `GitDiffOnOpenSourceTest` by increasing parameter count to satisfy `OverloadMethodsDeclarationOrder`.

Supersedes #434.